### PR TITLE
Replace `PyQt5` with `qtpy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,15 @@ dependencies = [
     "ibllib",
     "iblutil>=1.6.0",
     "pandas",
+    "qtpy",
 ]
+
+[project.optional-dependencies]
+pyqt5 = ["PyQt5>=5.15.0"]
+pyqt6 = ["PyQt6>=6.2.0"]
+pyside2 = ["PySide2>=5.15.0"]
+pyside6 = ["PySide6>=6.2.0"]
+qt = ["PyQt5>=5.15.0"]  # Default to PyQt5 for backward compatibility
 
 [project.urls]
 Homepage = "https://github.com/int-brain-lab/viewephys"

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import scipy.signal
 import pyqtgraph as pg
-from PyQt5 import QtGui, QtWidgets, QtCore, uic
+from qtpy import QtGui, QtWidgets, QtCore, uic
 
 import spikeglx
 from neuropixel import trace_header
@@ -239,7 +239,7 @@ class PickSpikes:
 
 
 class EphysViewer(EasyQC):
-    keyPressed = QtCore.pyqtSignal(int)
+    keyPressed = QtCore.Signal(int)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/viewephys/raster.py
+++ b/src/viewephys/raster.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import scipy.signal
 
-from PyQt5 import QtWidgets, QtCore, QtGui, uic
+from qtpy import QtWidgets, QtCore, QtGui, uic
 import pyqtgraph as pg
 
 from brainbox.processing import bincount2D


### PR DESCRIPTION
closes #8. This PR replaced PyQt5 with qtpy, the only issue is that easyqc still uses PyQt5 so there are some conflicts, see [comment](https://github.com/int-brain-lab/viewephys/issues/9#issuecomment-3824975114)