### PR TITLE
Attempt to fix possible pick-spikes issue

### DIFF
--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -351,8 +351,16 @@ class EphysViewer(EasyQC):
             )
         if event.buttons() != QtCore.Qt.LeftButton:
             return
-        TR_RANGE = 3
-        S_RANGE = int(0.5 / self.ctrl.model.si)
+
+        # Create the limits for a small window around the clicked point.
+        # We take 5% of the height and 2% of the width of the current
+        # view, as a rough general-purpose default.
+        current_view_s, current_view_tr = self.viewBox_seismic.state["viewRange"]
+        current_view_i = np.array(current_view_s) / self.ctrl.model.si
+        TR_RANGE = np.floor((current_view_tr[1] - current_view_tr[0]) * 0.05).astype(int)
+        S_RANGE = np.floor((current_view_i[1] - current_view_i[0]) * 0.02).astype(int)
+
+        self.plotItem_seismic.windowState
         qxy = self.imageItem_seismic.mapFromScene(event.scenePos())
         s, tr = (qxy.x(), qxy.y())
         # if event.buttons() == QtCore.Qt.MiddleButton:


### PR DESCRIPTION
Hey @oliche, when I tried the pick-spikes functionality, it worked well for CTRL+click but the auto-detect voltage was not working. For me at least, the calculated S_RANGE was very large, say (-15000, 15000) for 30kHz sampling. Typically the view window was around 0.33s, so the `out_of_time_range` was always triggered as `tscale[0]` was very negative. 

I proposed a fix in this PR, but I'm not 100% if its needed, I might just be doing something wrong. The fix creates the window to search for the voltage peak as a percentage of the current zoom (so, if the user is really zoomed it, a point is not detected outside of their view range). The percentages (5% of y, 2% of x) are arbitrary but felt okay when manually testing. I'm curious to know if you also had any issues with the pick spikes or if I'm mis-using it. Cheers!