### PR TITLE
Add option to view only a specific shank to BinaryFile

### DIFF
--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -43,7 +43,7 @@ SNS_PALETTE = [
 
 
 class EphysBinViewer(QtWidgets.QMainWindow):
-    def __init__(self, bin_file: str | Path | None = None, *args, **kwargs):
+    def __init__(self, bin_file: str | Path | None = None, shank_idx: int | None = None, *args, **kwargs):
         """
         Class for viewing a binary file output from SpikeGLX.
 
@@ -52,6 +52,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         When timepoint and processing steps are selected, it will
         spawn EphysViewer windows displaying the data.
 
+        :param bin_file: Path to the binary file to load
+        :param shank_idx: If not `None`, an integer indicating the shank to select for display.
         :param parent:
         :param sr: ibllib.io.spikeglx.Reader instance
         """
@@ -157,6 +159,11 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         first = int(float(self.horizontalSlider.value()) * NSAMP_CHUNK)
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
+
+        shank_ids = self.sr.geometry["shank"][:self.sr.nc - self.sr.nsync]
+        if self.shank_idx is not None:
+            shank_mask = shank_ids == int(self.shank_idx)
+            raw = raw[shank_mask, :]
 
         # get parameters for both AP and LFP band
         t0 = first / self.sr.fs * 0

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -43,7 +43,13 @@ SNS_PALETTE = [
 
 
 class EphysBinViewer(QtWidgets.QMainWindow):
-    def __init__(self, bin_file: str | Path | None = None, shank_idx: int | None = None, *args, **kwargs):
+    def __init__(
+        self,
+        bin_file: str | Path | None = None,
+        shank_idx: int | None = None,
+        *args,
+        **kwargs,
+    ):
         """
         Class for viewing a binary file output from SpikeGLX.
 
@@ -53,11 +59,13 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         spawn EphysViewer windows displaying the data.
 
         :param bin_file: Path to the binary file to load
-        :param shank_idx: If not `None`, an integer indicating the shank to select for display.
+        :param shank_idx: If not `None`, an integer indicating the shank to
+            select for display.
         :param parent:
         :param sr: ibllib.io.spikeglx.Reader instance
         """
         super().__init__(*args, *kwargs)
+        self.shank_idx = shank_idx
         self.settings = QtCore.QSettings("int-brain-lab", "EphysBinViewer")
         uic.loadUi(Path(__file__).parent.joinpath("nav_file.ui"), self)
         self.setWindowIcon(
@@ -160,9 +168,10 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 
-        shank_ids = self.sr.geometry["shank"][:self.sr.nc - self.sr.nsync]
+        shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
         if self.shank_idx is not None:
-            shank_mask = shank_ids == int(self.shank_idx)
+            assert isinstance(self.shank_idx, int), "`shank_idx` must be an `int`."
+            shank_mask = shank_ids == self.shank_idx
             raw = raw[shank_mask, :]
 
         # get parameters for both AP and LFP band

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -168,9 +168,10 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 
-        shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
         if self.shank_idx is not None:
             assert isinstance(self.shank_idx, int), "`shank_idx` must be an `int`."
+            
+            shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
             shank_mask = shank_ids == self.shank_idx
             raw = raw[shank_mask, :]
 

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -170,7 +170,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
 
         if self.shank_idx is not None:
             assert isinstance(self.shank_idx, int), "`shank_idx` must be an `int`."
-            
+
             shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
             shank_mask = shank_ids == self.shank_idx
             raw = raw[shank_mask, :]


### PR DESCRIPTION
This is a bit of a prototype PR but would be good to get your thoughts @oliche. For some data I have it sorted per-shank so it is nice to look only at that shank up-close. This PR adds an option to display only a selected shank.

I'm not sure if this is the best way to split the shank through the IBL API, I also only tested it for `spikeglx.Reader` so not sure if it will work for `ReaderClass`.

In general this should be better tested, and will have to be updated a lot once loading from spikeinterface is also supported. In terms of testing, I wonder if its easier to maintain a list of things to test, as there may be a lot of upcoming changes (e.g. spikeinterface reader, loading sorting output). Once we are happy with the form we can add a load of tests?