### PR TITLE
Add sorting reader

### DIFF
--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -171,7 +171,6 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         first = int(float(self.horizontalSlider.value()) * NSAMP_CHUNK)
         last = first + int(NSAMP_CHUNK)
 
-        breakpoint()
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 
         if self.shank_idx is not None:
@@ -228,8 +227,14 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                 t_scalar=T_SCALAR,
                 a_scalar=A_SCALAR,
             )
-
+            
+            # TODO: this is rough
             if self.sorting_dict is not None:
+                if self.shank
+                
+                
+                breakpoint()
+
 
                 ind_to_keep = np.searchsorted(self.sorting_dict["spike_times"], [first, last])
 
@@ -544,7 +549,7 @@ class EphysViewer(EasyQC):
             colors = {}
             for unit in np.unique(self.sorting_dict["unit_ids"]):
                 gen = np.random.default_rng(seed=unit)
-                colors[unit] = np.r_[gen.uniform(0.0, 0.5, 3) * 255, 255]
+                colors[unit] = np.r_[gen.uniform(0.5, 0.80, 3) * 255, 255]
             spike_colors = [colors[unit] for unit in self.sorting_dict["unit_ids"]]
         else:
             spike_colors = (125, 125, 125)

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -43,7 +43,7 @@ SNS_PALETTE = [
 
 
 class EphysBinViewer(QtWidgets.QMainWindow):
-    def __init__(self, bin_file: str | Path | None = None, *args, **kwargs):
+    def __init__(self, bin_file: str | Path | None = None, shank_idx: int | None = None, *args, **kwargs):
         """
         Class for viewing a binary file output from SpikeGLX.
 
@@ -52,6 +52,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         When timepoint and processing steps are selected, it will
         spawn EphysViewer windows displaying the data.
 
+        :param bin_file: Path to the binary file to load
+        :param shank_idx: If not `None`, an integer indicating the shank to select for display.
         :param parent:
         :param sr: ibllib.io.spikeglx.Reader instance
         """
@@ -157,6 +159,11 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         first = int(float(self.horizontalSlider.value()) * NSAMP_CHUNK)
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
+
+        shank_ids = self.sr.geometry["shank"][:self.sr.nc - self.sr.nsync]
+        if self.shank_idx is not None:
+            shank_mask = shank_ids == int(self.shank_idx)
+            raw = raw[shank_mask, :]
 
         # get parameters for both AP and LFP band
         t0 = first / self.sr.fs * 0

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -132,8 +132,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             self.sr = spikeglx.Reader(
                 file, dtype="int16", nc=384, fs=30000, ns=file.stat().st_size / 384 / 2
             )
-            
-        
+
+
         # enable and set slider, based on the number of samples in the entire file
         self.horizontalSlider.setMaximum(int(np.floor(self.sr.ns / NSAMP_CHUNK)))
         tmax = np.floor(self.sr.ns / NSAMP_CHUNK) * NSAMP_CHUNK / self.sr.fs
@@ -227,12 +227,12 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                 t_scalar=T_SCALAR,
                 a_scalar=A_SCALAR,
             )
-            
+
             # TODO: this is rough
             if self.sorting_dict is not None:
                 if self.shank
-                
-                
+
+
                 breakpoint()
 
 

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -43,7 +43,13 @@ SNS_PALETTE = [
 
 
 class EphysBinViewer(QtWidgets.QMainWindow):
-    def __init__(self, bin_file: str | Path | None = None, shank_idx: int | None = None, *args, **kwargs):
+    def __init__(
+        self,
+        bin_file: str | Path | None = None,
+        shank_idx: int | None = None,
+        *args,
+        **kwargs,
+    ):
         """
         Class for viewing a binary file output from SpikeGLX.
 
@@ -53,11 +59,13 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         spawn EphysViewer windows displaying the data.
 
         :param bin_file: Path to the binary file to load
-        :param shank_idx: If not `None`, an integer indicating the shank to select for display.
+        :param shank_idx: If not `None`, an integer indicating the shank to
+            select for display.
         :param parent:
         :param sr: ibllib.io.spikeglx.Reader instance
         """
         super().__init__(*args, *kwargs)
+        self.shank_idx = shank_idx
         self.settings = QtCore.QSettings("int-brain-lab", "EphysBinViewer")
         uic.loadUi(Path(__file__).parent.joinpath("nav_file.ui"), self)
         self.setWindowIcon(
@@ -160,9 +168,10 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 
-        shank_ids = self.sr.geometry["shank"][:self.sr.nc - self.sr.nsync]
+        shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
         if self.shank_idx is not None:
-            shank_mask = shank_ids == int(self.shank_idx)
+            assert isinstance(self.shank_idx, int), "`shank_idx` must be an `int`."
+            shank_mask = shank_ids == self.shank_idx
             raw = raw[shank_mask, :]
 
         # get parameters for both AP and LFP band

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -168,9 +168,10 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 
-        shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
         if self.shank_idx is not None:
             assert isinstance(self.shank_idx, int), "`shank_idx` must be an `int`."
+            
+            shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
             shank_mask = shank_ids == self.shank_idx
             raw = raw[shank_mask, :]
 

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -170,7 +170,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
 
         if self.shank_idx is not None:
             assert isinstance(self.shank_idx, int), "`shank_idx` must be an `int`."
-            
+
             shank_ids = self.sr.geometry["shank"][: self.sr.nc - self.sr.nsync]
             shank_mask = shank_ids == self.shank_idx
             raw = raw[shank_mask, :]


### PR DESCRIPTION
This is a rough prototyping PR to add spikes loaded from kilosort output to the GUI. It is branched from #22. Currently it does not load spikeinterface sorting analyzer, that is reserved for a separate PR. 

Since #22 makes it possible to show only a single shank, there are four cases to consider:

1) The file is displayed with all shanks, and the sorting contains all shanks
2) The file is displayed with all shanks, but the sorting is for a single shank
3) The file displays a single shank, and the sorting contains all shanks
4) The file displays a single shank, and the sorting is for a single shank

Currently the user must input the shank that the sorting is one (`None` for all) because I couldn't quickly figure out a way to infer the shank from the sorting output, however it is probably possible.

TODO MAJOR: 
- it is also possible that the raw data is split per shank. This case is not currently handled as it assumes the data is always multi-shank (even if we are only viewing a single shank).

TODO:
- refactor
- get feedback
- check carefully and think about all possible use cases, for example I have not tested the 1-shank case yet
- write some tests

An example script:

```
from viewephys.gui import EphysBinViewer
from pathlib import Path
import easyqc
import numpy as np

app = easyqc.qt.create_app()

sorting_path = r"Y:\...\path_to_sorter_output"


# i.e. only display the first shank, + the sorting is multi-shank
# (the software will figure out displaying the correct spikes)
viewer = EphysBinViewer(
    r"path/to/data/g0_tcat.imec0.ap.bin",
    shank_idx=1, sorting_path=dat_path, sorting_shank_idx=None,
)

app.exec()
```


