### PR TITLE
Slider zoom fix and jump to a time point option

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,40 @@
+# .github/workflows/publish-pypi.yml
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish viewephys to PyPI
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write   # required for PyPI trusted publishing
+
+    environment: pypi
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PDM
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pdm install -G :all
+
+      - name: Run ruff
+        run: pdm run ruff check .
+
+      - name: Clean old build artifacts
+        run: |
+          rm -rf dist
+          rm -rf .pdm-build
+
+      - name: Publish to PyPI
+        run: pdm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.0] - 2026-04-30
+
+### added
+- "Jump to" time entry in the EphysBinViewer for navigating to a specific timepoint
+- Jump-to navigation loads the window starting at the closest sample, rather than snapping to the horizontal slider's 10000-sample discretisation
+- Preserve the current zoom range across slider/jump-to reloads in the EphysBinViewer
+
 ## [1.1.2] - 2026-04-21
 
 ### changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viewephys"
-version = "1.1.2"
+version = "1.2.0"
 description = "Neuropixel raw data viewer"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "scipy",
 ]
 
+
 [project.optional-dependencies]
 dev = [
   "pytest",

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -67,9 +67,10 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.horizontalSlider.setMinimum(0)
         self.horizontalSlider.setSingleStep(1)
         self.horizontalSlider.setTickInterval(10)
+        self._first_sample = 0
         self.horizontalSlider.sliderReleased.connect(self.on_horizontalSliderReleased)
         self.horizontalSlider.valueChanged.connect(self.on_horizontalSliderValueChanged)
-        validator = QtGui.QDoubleValidator(0.0, 1e12, 3, self.lineEdit_jumpTime)
+        validator = QtGui.QDoubleValidator(0.0, 1e12, 6, self.lineEdit_jumpTime)
         validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
         self.lineEdit_jumpTime.setValidator(validator)
         self.lineEdit_jumpTime.returnPressed.connect(self.on_jumpToTimeRequested)
@@ -140,18 +141,24 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         )
         self.label.setText(tlabel)
         self.horizontalSlider.setValue(0)
+        self._first_sample = 0
         self.horizontalSlider.setEnabled(True)
         self.lineEdit_jumpTime.setEnabled(True)
         self.pushButton_jumpTime.setEnabled(True)
         self.on_horizontalSliderReleased()
 
     def on_horizontalSliderValueChanged(self) -> None:
-        tcur = self.horizontalSlider.value() * NSAMP_CHUNK / self.sr.fs
-        self.label_sval.setText(f"{tcur:0.2f}s")
+        self._first_sample = int(self.horizontalSlider.value()) * NSAMP_CHUNK
+        self._update_time_label()
+
+    def _update_time_label(self) -> None:
+        tcur = self._first_sample / self.sr.fs
+        self.label_sval.setText(f"{tcur:0.6f}s")
 
     def on_jumpToTimeRequested(self) -> None:
-        """Jump to the user-typed time (seconds), snapping to
-        the nearest valid window."""
+        """Jump to the user-typed time (seconds), loading the window
+        starting at the closest sample. The slider thumb is moved to the
+        nearest chunk for visual feedback only."""
         text = self.lineEdit_jumpTime.text().strip()
         if text == "" or not hasattr(self, "sr"):
             return
@@ -159,14 +166,18 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             t = float(text)
         except ValueError:
             return
-        slider_max = self.horizontalSlider.maximum()
-        value = int(round(t * self.sr.fs / NSAMP_CHUNK))
-        value = max(0, min(value, slider_max))
-        self.horizontalSlider.setValue(value)
-        # setValue does not emit valueChanged when the value is unchanged,
-        # so refresh the
-        # label explicitly to handle the value-already-equal-to-target case.
-        self.on_horizontalSliderValueChanged()
+        max_first = max(0, int(self.sr.ns) - NSAMP_CHUNK)
+        first_sample = int(round(t * self.sr.fs))
+        first_sample = max(0, min(first_sample, max_first))
+        self._first_sample = first_sample
+        slider_value = int(round(first_sample / NSAMP_CHUNK))
+        slider_value = max(0, min(slider_value, self.horizontalSlider.maximum()))
+        # Move slider for visual feedback without letting valueChanged
+        # overwrite the exact first_sample we just set.
+        self.horizontalSlider.blockSignals(True)
+        self.horizontalSlider.setValue(slider_value)
+        self.horizontalSlider.blockSignals(False)
+        self._update_time_label()
         self.on_horizontalSliderReleased()
 
     def on_horizontalSliderReleased(self) -> None:  # noqa: C901
@@ -191,7 +202,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             else:
                 prev_ranges[k] = None
 
-        first = int(float(self.horizontalSlider.value()) * NSAMP_CHUNK)
+        first = int(self._first_sample)
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -158,9 +158,10 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.label_sval.setText(f"{tcur:0.6f}s")
 
     def on_jumpToTimeRequested(self) -> None:
-        """Jump to the user-typed time (seconds), loading the window
-        starting at the closest sample. The slider thumb is moved to the
-        nearest chunk for visual feedback only."""
+        """Jump to the user-typed time, centering the loaded window on it.
+
+        The slider thumb is moved to the nearest chunk for visual feedback only.
+        """
         text = self.lineEdit_jumpTime.text().strip()
         if text == "" or not hasattr(self, "sr"):
             return
@@ -168,9 +169,12 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             t = float(text)
         except ValueError:
             return
+        requested_sample = int(round(t * self.sr.fs))
+        requested_sample = max(0, min(requested_sample, int(self.sr.ns) - 1))
         max_first = max(0, int(self.sr.ns) - NSAMP_CHUNK)
-        first_sample = int(round(t * self.sr.fs))
+        first_sample = requested_sample - NSAMP_CHUNK // 2
         first_sample = max(0, min(first_sample, max_first))
+        center_time = requested_sample / self.sr.fs
         self._first_sample = first_sample
         slider_value = int(round(first_sample / NSAMP_CHUNK))
         slider_value = max(0, min(slider_value, self.horizontalSlider.maximum()))
@@ -180,16 +184,18 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.horizontalSlider.setValue(slider_value)
         self.horizontalSlider.blockSignals(False)
         self._update_time_label()
-        self.on_horizontalSliderReleased()
+        self.on_horizontalSliderReleased(center_time=center_time)
 
-    def on_horizontalSliderReleased(self) -> None:  # noqa: C901
+    def on_horizontalSliderReleased(  # noqa: C901
+        self, center_time: float | None = None
+    ) -> None:
         """
         Open EphysViewer windows at the selected timepoint
         for the selected preprocessing steps.
 
-        The horizontal slider allows the user to select the timepoint
-        at which they would like to see the data. This will open EphysVeiewer
-        windows at a window starting at that time point.
+        The horizontal slider opens EphysViewer windows starting at the
+        selected timepoint. Jump requests may pass ``center_time`` so existing
+        viewer zoom is preserved around the requested absolute time.
 
         Depending on the selected preprocessing steps, open a number of
         viewers (one for each selected preprocessing step) to display the
@@ -209,7 +215,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
 
         # get parameters for both AP and LFP band
-        t0 = first / self.sr.fs * 0
+        t0 = first / self.sr.fs
         if self.sr.type == "lf":
             butter_kwargs = {"N": 3, "Wn": 3 / self.sr.fs * 2, "btype": "highpass"}
             fcn_destripe = voltage.destripe_lfp
@@ -260,8 +266,19 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             if prev is not None:
                 xr_prev, yr_prev = prev
                 width = xr_prev[1] - xr_prev[0]
-                new_x0 = t0 * T_SCALAR
-                viewer.viewBox_seismic.setXRange(new_x0, new_x0 + width, padding=0)
+                xmin, xmax = viewer.ctrl.limits()[0]
+                if center_time is None:
+                    new_x0 = t0 * T_SCALAR
+                else:
+                    new_x0 = center_time * T_SCALAR - width / 2
+
+                # Preserve the previous zoom width without panning past the data.
+                if width >= xmax - xmin:
+                    new_x0, new_x1 = xmin, xmax
+                else:
+                    new_x0 = max(xmin, min(new_x0, xmax - width))
+                    new_x1 = new_x0 + width
+                viewer.viewBox_seismic.setXRange(new_x0, new_x1, padding=0)
                 viewer.viewBox_seismic.setYRange(yr_prev[0], yr_prev[1], padding=0)
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -150,7 +150,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.label_sval.setText(f"{tcur:0.2f}s")
 
     def on_jumpToTimeRequested(self) -> None:
-        """Jump to the user-typed time (seconds), snapping to the nearest valid window."""
+        """Jump to the user-typed time (seconds), snapping to
+        the nearest valid window."""
         text = self.lineEdit_jumpTime.text().strip()
         if text == "" or not hasattr(self, "sr"):
             return
@@ -162,12 +163,13 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         value = int(round(t * self.sr.fs / NSAMP_CHUNK))
         value = max(0, min(value, slider_max))
         self.horizontalSlider.setValue(value)
-        # setValue does not emit valueChanged when the value is unchanged, so refresh the
+        # setValue does not emit valueChanged when the value is unchanged,
+        # so refresh the
         # label explicitly to handle the value-already-equal-to-target case.
         self.on_horizontalSliderValueChanged()
         self.on_horizontalSliderReleased()
 
-    def on_horizontalSliderReleased(self) -> None:
+    def on_horizontalSliderReleased(self) -> None:  # noqa: C901
         """
         Open EphysViewer windows at the selected timepoint
         for the selected preprocessing steps.
@@ -231,7 +233,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                     sos = scipy.signal.butter(**butter_kwargs, output="sos")
                     data = scipy.signal.sosfiltfilt(sos, raw)
 
-            self.viewers[k] = viewephys(
+            viewer = viewephys(
                 data,
                 self.sr.fs,
                 channels=self.sr.geometry,
@@ -240,17 +242,14 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                 t_scalar=T_SCALAR,
                 a_scalar=A_SCALAR,
             )
+            self.viewers[k] = viewer
             prev = prev_ranges.get(k)
             if prev is not None:
                 xr_prev, yr_prev = prev
                 width = xr_prev[1] - xr_prev[0]
                 new_x0 = t0 * T_SCALAR
-                self.viewers[k].viewBox_seismic.setXRange(
-                    new_x0, new_x0 + width, padding=0
-                )
-                self.viewers[k].viewBox_seismic.setYRange(
-                    yr_prev[0], yr_prev[1], padding=0
-                )
+                viewer.viewBox_seismic.setXRange(new_x0, new_x0 + width, padding=0)
+                viewer.viewBox_seismic.setYRange(yr_prev[0], yr_prev[1], padding=0)
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -180,6 +180,15 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         viewers (one for each selected preprocessing step) to display the
         preprocessed data at the selected timepoint.
         """
+        # Capture current zoom per visible viewer so we can restore it after the reload.
+        prev_ranges: dict[str, tuple[list[float], list[float]] | None] = {}
+        for k, ev in self.viewers.items():
+            if ev is not None and ev.isVisible():
+                xr, yr = ev.viewBox_seismic.viewRange()
+                prev_ranges[k] = (list(xr), list(yr))
+            else:
+                prev_ranges[k] = None
+
         first = int(float(self.horizontalSlider.value()) * NSAMP_CHUNK)
         last = first + int(NSAMP_CHUNK)
         raw = self.sr[first:last, : self.sr.nc - self.sr.nsync].T
@@ -231,6 +240,17 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                 t_scalar=T_SCALAR,
                 a_scalar=A_SCALAR,
             )
+            prev = prev_ranges.get(k)
+            if prev is not None:
+                xr_prev, yr_prev = prev
+                width = xr_prev[1] - xr_prev[0]
+                new_x0 = t0 * T_SCALAR
+                self.viewers[k].viewBox_seismic.setXRange(
+                    new_x0, new_x0 + width, padding=0
+                )
+                self.viewers[k].viewBox_seismic.setYRange(
+                    yr_prev[0], yr_prev[1], padding=0
+                )
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -69,6 +69,11 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.horizontalSlider.setTickInterval(10)
         self.horizontalSlider.sliderReleased.connect(self.on_horizontalSliderReleased)
         self.horizontalSlider.valueChanged.connect(self.on_horizontalSliderValueChanged)
+        validator = QtGui.QDoubleValidator(0.0, 1e12, 3, self.lineEdit_jumpTime)
+        validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        self.lineEdit_jumpTime.setValidator(validator)
+        self.lineEdit_jumpTime.returnPressed.connect(self.on_jumpToTimeRequested)
+        self.pushButton_jumpTime.clicked.connect(self.on_jumpToTimeRequested)
         self.label_smin.setText("0")
         self.show()
 
@@ -136,11 +141,31 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.label.setText(tlabel)
         self.horizontalSlider.setValue(0)
         self.horizontalSlider.setEnabled(True)
+        self.lineEdit_jumpTime.setEnabled(True)
+        self.pushButton_jumpTime.setEnabled(True)
         self.on_horizontalSliderReleased()
 
     def on_horizontalSliderValueChanged(self) -> None:
         tcur = self.horizontalSlider.value() * NSAMP_CHUNK / self.sr.fs
         self.label_sval.setText(f"{tcur:0.2f}s")
+
+    def on_jumpToTimeRequested(self) -> None:
+        """Jump to the user-typed time (seconds), snapping to the nearest valid window."""
+        text = self.lineEdit_jumpTime.text().strip()
+        if text == "" or not hasattr(self, "sr"):
+            return
+        try:
+            t = float(text)
+        except ValueError:
+            return
+        slider_max = self.horizontalSlider.maximum()
+        value = int(round(t * self.sr.fs / NSAMP_CHUNK))
+        value = max(0, min(value, slider_max))
+        self.horizontalSlider.setValue(value)
+        # setValue does not emit valueChanged when the value is unchanged, so refresh the
+        # label explicitly to handle the value-already-equal-to-target case.
+        self.on_horizontalSliderValueChanged()
+        self.on_horizontalSliderReleased()
 
     def on_horizontalSliderReleased(self) -> None:
         """

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -72,6 +72,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.horizontalSlider.valueChanged.connect(self.on_horizontalSliderValueChanged)
         validator = QtGui.QDoubleValidator(0.0, 1e12, 6, self.lineEdit_jumpTime)
         validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        # To handle dot as decimal separator regardless of user locale
+        validator.setLocale(QtCore.QLocale.c())
         self.lineEdit_jumpTime.setValidator(validator)
         self.lineEdit_jumpTime.returnPressed.connect(self.on_jumpToTimeRequested)
         self.pushButton_jumpTime.clicked.connect(self.on_jumpToTimeRequested)

--- a/src/viewephys/nav_file.ui
+++ b/src/viewephys/nav_file.ui
@@ -135,6 +135,70 @@
       </layout>
      </widget>
     </item>
+    <item row="6" column="0">
+     <widget class="QFrame" name="frame_3">
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>40</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_jumpTime">
+       <item>
+        <widget class="QLabel" name="label_jumpTime">
+         <property name="text">
+          <string>Jump to:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEdit_jumpTime">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>120</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="placeholderText">
+          <string>seconds</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_jumpTime">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Go</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_jumpTime">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pytest
 from qtpy import QtCore
 
+from viewephys.gui import NSAMP_CHUNK, EphysBinViewer
 from viewephys.tests.test_viewer_helpers import synthetic_seismic_data
 from viewephys.viewer.gui import EasyQC, viewseis
 
@@ -62,3 +64,73 @@ def test_toggle_density_wiggle(view_with_data, qtbot):
     assert window.imageItem_seismic.image is None
     qtbot.mouseClick(window.radio_density, QtCore.Qt.LeftButton)
     assert window._display_mode == "density"
+
+
+class _FakeSR:
+    """Minimal stand-in for spikeglx.Reader, exposing only what the jump logic reads."""
+
+    fs = 30000.0
+    ns = 30000 * 2200  # 2200 s recording, like the screenshot in the request
+
+
+@pytest.fixture
+def jump_window(qtbot, monkeypatch):
+    window = EphysBinViewer()
+    qtbot.addWidget(window)
+    window.sr = _FakeSR()
+    slider_max = int(np.floor(window.sr.ns / NSAMP_CHUNK))
+    window.horizontalSlider.setMaximum(slider_max)
+    window.horizontalSlider.setEnabled(True)
+    window.lineEdit_jumpTime.setEnabled(True)
+    window.pushButton_jumpTime.setEnabled(True)
+    monkeypatch.setattr(window, "on_horizontalSliderReleased", lambda: None)
+    window.show()
+    qtbot.wait(50)
+    yield window
+    window.close()
+    window.deleteLater()
+    qtbot.wait(50)
+
+
+@pytest.mark.parametrize(
+    "typed_seconds",
+    [0.0, 0.4, 0.5, 100.0, 500.0, 1173.67, 2199.99],
+)
+def test_jump_to_time_snaps_to_nearest_sample(jump_window, qtbot, typed_seconds):
+    window = jump_window
+    expected_value = int(round(typed_seconds * window.sr.fs / NSAMP_CHUNK))
+    expected_value = max(0, min(expected_value, window.horizontalSlider.maximum()))
+    expected_t = expected_value * NSAMP_CHUNK / window.sr.fs
+
+    window.lineEdit_jumpTime.setText(str(typed_seconds))
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+
+    assert window.horizontalSlider.value() == expected_value
+    actual_t = window.horizontalSlider.value() * NSAMP_CHUNK / window.sr.fs
+    assert abs(actual_t - typed_seconds) <= (NSAMP_CHUNK / window.sr.fs) / 2 + 1e-9
+    assert window.label_sval.text() == f"{expected_t:0.2f}s"
+
+
+def test_jump_to_time_clamps_out_of_range(jump_window, qtbot):
+    window = jump_window
+    slider_max = window.horizontalSlider.maximum()
+
+    window.lineEdit_jumpTime.setText("-50")
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    assert window.horizontalSlider.value() == 0
+
+    window.lineEdit_jumpTime.setText("99999")
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    assert window.horizontalSlider.value() == slider_max
+
+
+def test_jump_to_time_ignores_garbage(jump_window, qtbot):
+    window = jump_window
+    window.horizontalSlider.setValue(42)
+    window.lineEdit_jumpTime.setText("abc")
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    assert window.horizontalSlider.value() == 42
+
+    window.lineEdit_jumpTime.setText("")
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    assert window.horizontalSlider.value() == 42

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -73,6 +73,75 @@ class _FakeSR:
     ns = 30000 * 2200  # 2200 s recording, like the screenshot in the request
 
 
+class _FakeArraySR(_FakeSR):
+    """Small array reader used to test jump reloads without a real binary file."""
+
+    nc = 4
+    nsync = 0
+    type = "ap"
+    geometry = {"trace": np.arange(nc)}
+
+    def __getitem__(self, key):
+        sample_slice, channel_slice = key
+        first = 0 if sample_slice.start is None else sample_slice.start
+        last = self.ns if sample_slice.stop is None else sample_slice.stop
+        first_channel = 0 if channel_slice.start is None else channel_slice.start
+        last_channel = self.nc if channel_slice.stop is None else channel_slice.stop
+        shape = (last - first, last_channel - first_channel)
+        return np.zeros(shape, dtype=np.float32)
+
+
+class _FakeViewBox:
+    """Minimal view box that records range changes made by the jump code."""
+
+    def __init__(self, view_range=None):
+        self._view_range = view_range or ([0.0, 1.0], [0.0, 1.0])
+        self.xrange = None
+        self.yrange = None
+
+    def viewRange(self):
+        return self._view_range
+
+    def setXRange(self, x0, x1, padding=0):
+        self.xrange = (x0, x1, padding)
+
+    def setYRange(self, y0, y1, padding=0):
+        self.yrange = (y0, y1, padding)
+
+
+class _FakeCtrl:
+    """Minimal controller exposing data limits for range clamping."""
+
+    def __init__(self, xlim):
+        self._xlim = xlim
+
+    def limits(self):
+        return self._xlim, [0.0, 1.0]
+
+
+class _FakeViewer:
+    """Small viewer object used to test range preservation."""
+
+    def __init__(self, xlim=None, view_range=None):
+        self.viewBox_seismic = _FakeViewBox(view_range=view_range)
+        self.ctrl = _FakeCtrl(xlim or [0.0, 1.0])
+
+    def isVisible(self):
+        return True
+
+    def close(self):
+        return None
+
+
+def _centered_first_sample(typed_seconds, fs, ns):
+    """Return the expected first sample after centering a jump request."""
+    requested_sample = int(round(typed_seconds * fs))
+    requested_sample = max(0, min(requested_sample, int(ns) - 1))
+    max_first = max(0, int(ns) - NSAMP_CHUNK)
+    first_sample = requested_sample - NSAMP_CHUNK // 2
+    return max(0, min(first_sample, max_first))
+
+
 @pytest.fixture
 def jump_window(qtbot, monkeypatch):
     window = EphysBinViewer()
@@ -83,7 +152,9 @@ def jump_window(qtbot, monkeypatch):
     window.horizontalSlider.setEnabled(True)
     window.lineEdit_jumpTime.setEnabled(True)
     window.pushButton_jumpTime.setEnabled(True)
-    monkeypatch.setattr(window, "on_horizontalSliderReleased", lambda: None)
+    monkeypatch.setattr(
+        window, "on_horizontalSliderReleased", lambda center_time=None: None
+    )
     window.show()
     qtbot.wait(50)
     yield window
@@ -97,13 +168,11 @@ def jump_window(qtbot, monkeypatch):
     [0.0, 0.4, 0.5, 100.0, 500.0, 500.150, 1173.67, 2199.99],
 )
 def test_jump_to_time_loads_exact_sample(jump_window, qtbot, typed_seconds):
-    """Jump-to should load the window starting at the closest sample, while
-    parking the slider at the nearest chunk for visual feedback only."""
+    """Jump-to should center the window on the requested sample, while
+    parking the slider near the loaded window for visual feedback only."""
     window = jump_window
     fs = window.sr.fs
-    max_first = max(0, int(window.sr.ns) - NSAMP_CHUNK)
-    expected_first = int(round(typed_seconds * fs))
-    expected_first = max(0, min(expected_first, max_first))
+    expected_first = _centered_first_sample(typed_seconds, fs, window.sr.ns)
     expected_slider = max(
         0,
         min(
@@ -121,16 +190,16 @@ def test_jump_to_time_loads_exact_sample(jump_window, qtbot, typed_seconds):
 
 
 def test_jump_to_time_non_chunk_aligned(jump_window, qtbot):
-    """Sanity check that 500.150 s lands on its exact sample, not the
-    nearest 10000-sample chunk (which would be 500.000 or 500.333)."""
+    """Sanity check that 500.150 s lands at the center of the loaded window."""
     window = jump_window
     window.lineEdit_jumpTime.setText("500.150")
-    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    window.on_jumpToTimeRequested()
 
-    assert window._first_sample == int(round(500.150 * window.sr.fs))
-    assert window._first_sample == 15_004_500
+    requested_sample = int(round(500.150 * window.sr.fs))
+    assert window._first_sample + NSAMP_CHUNK // 2 == requested_sample
+    assert window._first_sample == 14_999_500
     assert window.horizontalSlider.value() == 1500
-    assert window.label_sval.text() == "500.150000s"
+    assert window.label_sval.text() == "499.983333s"
 
 
 def test_slider_drag_resets_first_sample_to_chunk(jump_window, qtbot):
@@ -140,7 +209,7 @@ def test_slider_drag_resets_first_sample_to_chunk(jump_window, qtbot):
     window = jump_window
     window.lineEdit_jumpTime.setText("500.150")
     qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
-    assert window._first_sample == 15_004_500  # not chunk-aligned
+    assert window._first_sample == 14_999_500  # not chunk-aligned
 
     window.horizontalSlider.setValue(1501)
     assert window._first_sample == 1501 * NSAMP_CHUNK
@@ -175,3 +244,40 @@ def test_jump_to_time_ignores_garbage(jump_window, qtbot):
     window.lineEdit_jumpTime.setText("")
     qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
     assert window.horizontalSlider.value() == 42
+
+
+def test_jump_to_time_recenters_existing_zoom(qtbot, monkeypatch):
+    """Reloaded viewers should keep zoom width and recenter on the jump time."""
+    window = EphysBinViewer()
+    qtbot.addWidget(window)
+    window.sr = _FakeArraySR()
+    window.horizontalSlider.setMaximum(int(np.floor(window.sr.ns / NSAMP_CHUNK)))
+    for checkbox in window.cbs.values():
+        checkbox.setChecked(False)
+    window.cbs["raw"].setChecked(True)
+    window.viewers["raw"] = _FakeViewer(view_range=([400.0, 400.1], [10.0, 20.0]))
+
+    captured = {}
+
+    def fake_viewephys(data, fs, channels=None, title="ephys", t0=0.0, **kwargs):
+        """Return a fake viewer with the same x-limits as the displayed chunk."""
+        viewer = _FakeViewer(xlim=[t0, t0 + data.shape[1] / fs])
+        captured["t0"] = t0
+        captured["viewer"] = viewer
+        return viewer
+
+    monkeypatch.setattr("viewephys.gui.viewephys", fake_viewephys)
+
+    window.lineEdit_jumpTime.setText("500.150")
+    window.on_jumpToTimeRequested()
+
+    x0, x1, padding = captured["viewer"].viewBox_seismic.xrange
+    y0, y1, y_padding = captured["viewer"].viewBox_seismic.yrange
+    assert captured["t0"] == pytest.approx(window._first_sample / window.sr.fs)
+    assert (x0 + x1) / 2 == pytest.approx(500.150)
+    assert x1 - x0 == pytest.approx(0.1)
+    assert padding == 0
+    assert (y0, y1, y_padding) == (10.0, 20.0, 0)
+
+    window.close()
+    window.deleteLater()

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -94,34 +94,75 @@ def jump_window(qtbot, monkeypatch):
 
 @pytest.mark.parametrize(
     "typed_seconds",
-    [0.0, 0.4, 0.5, 100.0, 500.0, 1173.67, 2199.99],
+    [0.0, 0.4, 0.5, 100.0, 500.0, 500.150, 1173.67, 2199.99],
 )
-def test_jump_to_time_snaps_to_nearest_sample(jump_window, qtbot, typed_seconds):
+def test_jump_to_time_loads_exact_sample(jump_window, qtbot, typed_seconds):
+    """Jump-to should load the window starting at the closest sample, while
+    parking the slider at the nearest chunk for visual feedback only."""
     window = jump_window
-    expected_value = int(round(typed_seconds * window.sr.fs / NSAMP_CHUNK))
-    expected_value = max(0, min(expected_value, window.horizontalSlider.maximum()))
-    expected_t = expected_value * NSAMP_CHUNK / window.sr.fs
+    fs = window.sr.fs
+    max_first = max(0, int(window.sr.ns) - NSAMP_CHUNK)
+    expected_first = int(round(typed_seconds * fs))
+    expected_first = max(0, min(expected_first, max_first))
+    expected_slider = max(
+        0,
+        min(
+            int(round(expected_first / NSAMP_CHUNK)), window.horizontalSlider.maximum()
+        ),
+    )
+    expected_t = expected_first / fs
 
     window.lineEdit_jumpTime.setText(str(typed_seconds))
     qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
 
-    assert window.horizontalSlider.value() == expected_value
-    actual_t = window.horizontalSlider.value() * NSAMP_CHUNK / window.sr.fs
-    assert abs(actual_t - typed_seconds) <= (NSAMP_CHUNK / window.sr.fs) / 2 + 1e-9
-    assert window.label_sval.text() == f"{expected_t:0.2f}s"
+    assert window._first_sample == expected_first
+    assert window.horizontalSlider.value() == expected_slider
+    assert window.label_sval.text() == f"{expected_t:0.6f}s"
+
+
+def test_jump_to_time_non_chunk_aligned(jump_window, qtbot):
+    """Sanity check that 500.150 s lands on its exact sample, not the
+    nearest 10000-sample chunk (which would be 500.000 or 500.333)."""
+    window = jump_window
+    window.lineEdit_jumpTime.setText("500.150")
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+
+    assert window._first_sample == int(round(500.150 * window.sr.fs))
+    assert window._first_sample == 15_004_500
+    assert window.horizontalSlider.value() == 1500
+    assert window.label_sval.text() == "500.150000s"
+
+
+def test_slider_drag_resets_first_sample_to_chunk(jump_window, qtbot):
+    """After a non-chunk-aligned jump, dragging the slider must snap
+    `_first_sample` back to the chunk boundary so subsequent loads use the
+    slider position."""
+    window = jump_window
+    window.lineEdit_jumpTime.setText("500.150")
+    qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    assert window._first_sample == 15_004_500  # not chunk-aligned
+
+    window.horizontalSlider.setValue(1501)
+    assert window._first_sample == 1501 * NSAMP_CHUNK
+    assert window.label_sval.text() == f"{1501 * NSAMP_CHUNK / window.sr.fs:0.6f}s"
 
 
 def test_jump_to_time_clamps_out_of_range(jump_window, qtbot):
     window = jump_window
-    slider_max = window.horizontalSlider.maximum()
+    max_first = max(0, int(window.sr.ns) - NSAMP_CHUNK)
+    expected_slider_high = max(
+        0, min(int(round(max_first / NSAMP_CHUNK)), window.horizontalSlider.maximum())
+    )
 
     window.lineEdit_jumpTime.setText("-50")
     qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
+    assert window._first_sample == 0
     assert window.horizontalSlider.value() == 0
 
     window.lineEdit_jumpTime.setText("99999")
     qtbot.keyPress(window.lineEdit_jumpTime, QtCore.Qt.Key_Return)
-    assert window.horizontalSlider.value() == slider_max
+    assert window._first_sample == max_first
+    assert window.horizontalSlider.value() == expected_slider_high
 
 
 def test_jump_to_time_ignores_garbage(jump_window, qtbot):


### PR DESCRIPTION
 - Add a option to jump to a specific time point in the recording (if the exact time point is not found, it tries to reach the nearest time point )
  - Now we keep the same zoom level , when the slider is moved to different time points.