### PR TITLE
Fix pick-spikes auto-detect window and QSettings int cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### fixed
+- Pick-spikes auto-detect window now scales with the current zoom level instead of using a fixed half-second range, preventing false `out_of_time_range` rejections at high sample rates (thanks @JoeZiminski)
+- `QSettings.value()` cast to `int` for `nfft`/`nperseg` in `ImShowSpectrogram` to avoid `TypeError` on `//` operator
+
 ## [1.2.0] - 2026-04-30
 
 ### added

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -504,7 +504,9 @@ class EphysViewer(EasyQC):
         # view, as a rough general-purpose default.
         current_view_s, current_view_tr = self.viewBox_seismic.viewRange()
         current_view_i = np.array(current_view_s) / self.ctrl.model.si
-        TR_RANGE = np.floor((current_view_tr[1] - current_view_tr[0]) * 0.05).astype(int)
+        TR_RANGE = np.floor(
+            (current_view_tr[1] - current_view_tr[0]) * 0.05
+        ).astype(int)
         S_RANGE = np.floor((current_view_i[1] - current_view_i[0]) * 0.02).astype(int)
         qxy = self.imageItem_seismic.mapFromScene(event.scenePos())
         s, tr = (qxy.x(), qxy.y())

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -502,12 +502,10 @@ class EphysViewer(EasyQC):
         # Create the limits for a small window around the clicked point.
         # We take 5% of the height and 2% of the width of the current
         # view, as a rough general-purpose default.
-        current_view_s, current_view_tr = self.viewBox_seismic.state["viewRange"]
+        current_view_s, current_view_tr = self.viewBox_seismic.viewRange()
         current_view_i = np.array(current_view_s) / self.ctrl.model.si
         TR_RANGE = np.floor((current_view_tr[1] - current_view_tr[0]) * 0.05).astype(int)
         S_RANGE = np.floor((current_view_i[1] - current_view_i[0]) * 0.02).astype(int)
-
-        self.plotItem_seismic.windowState
         qxy = self.imageItem_seismic.mapFromScene(event.scenePos())
         s, tr = (qxy.x(), qxy.y())
         # if event.buttons() == QtCore.Qt.MiddleButton:

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -498,8 +498,16 @@ class EphysViewer(EasyQC):
             )
         if event.buttons() != QtCore.Qt.MouseButton.LeftButton:
             return
-        TR_RANGE = 3
-        S_RANGE = int(0.5 / self.ctrl.model.si)
+
+        # Create the limits for a small window around the clicked point.
+        # We take 5% of the height and 2% of the width of the current
+        # view, as a rough general-purpose default.
+        current_view_s, current_view_tr = self.viewBox_seismic.state["viewRange"]
+        current_view_i = np.array(current_view_s) / self.ctrl.model.si
+        TR_RANGE = np.floor((current_view_tr[1] - current_view_tr[0]) * 0.05).astype(int)
+        S_RANGE = np.floor((current_view_i[1] - current_view_i[0]) * 0.02).astype(int)
+
+        self.plotItem_seismic.windowState
         qxy = self.imageItem_seismic.mapFromScene(event.scenePos())
         s, tr = (qxy.x(), qxy.y())
         # if event.buttons() == QtCore.Qt.MiddleButton:

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -504,9 +504,9 @@ class EphysViewer(EasyQC):
         # view, as a rough general-purpose default.
         current_view_s, current_view_tr = self.viewBox_seismic.viewRange()
         current_view_i = np.array(current_view_s) / self.ctrl.model.si
-        TR_RANGE = np.floor(
-            (current_view_tr[1] - current_view_tr[0]) * 0.05
-        ).astype(int)
+        TR_RANGE = np.floor((current_view_tr[1] - current_view_tr[0]) * 0.05).astype(
+            int
+        )
         S_RANGE = np.floor((current_view_i[1] - current_view_i[0]) * 0.02).astype(int)
         qxy = self.imageItem_seismic.mapFromScene(event.scenePos())
         s, tr = (qxy.x(), qxy.y())

--- a/src/viewephys/viewer/pgtools.py
+++ b/src/viewephys/viewer/pgtools.py
@@ -27,11 +27,11 @@ class ImShowSpectrogram(QtWidgets.QMainWindow):
 
     @property
     def nfft(self):
-        return self.settings.value("nfft", 512)
+        return int(self.settings.value("nfft", 512))
 
     @property
     def nperseg(self):
-        return self.settings.value("nperseg", 256)
+        return int(self.settings.value("nperseg", 256))
 
     @property
     def noverlap(self):


### PR DESCRIPTION
Closes #18. Original fix by @JoeZiminski — rebased on main and cleaned up.

## Changes
- Replace hard-coded `S_RANGE`/`TR_RANGE` with view-percentage-based values (2%/5% of current zoom) so the auto-detect window does not escape the visible range at high sample rates
- Use `viewBox_seismic.viewRange()` public API instead of `.state["viewRange"]` internal dict
- Remove dead `self.plotItem_seismic.windowState` line
- Fix `QSettings.value()` returning `str` for `nfft`/`nperseg` in `ImShowSpectrogram`, causing `TypeError` on `//` — cast to `int` at the property level