### PR TITLE
Add descending sort.

### DIFF
--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -66,6 +66,40 @@ def test_toggle_density_wiggle(view_with_data, qtbot):
     assert window._display_mode == "density"
 
 
+def test_sort_reorders_plotted_image_multiple_keys(view_with_data):
+    """Sorting by multiple keys should reorder the plotted image
+    without mutating the header.
+    """
+    window = view_with_data
+    original_header = {
+        key: values.copy() for key, values in window.model.header.items()
+    }
+    keys = ["receiver_number", "receiver_line"]
+    expected_indices = np.lexsort(
+        [window.model.header["receiver_number"], window.model.header["receiver_line"]]
+    )
+    expected_image = window.model.data[expected_indices, :]
+
+    window.ctrl.sort(keys)
+
+    np.testing.assert_array_equal(window.ctrl.trace_indices, expected_indices)
+    np.testing.assert_array_equal(window.imageItem_seismic.image, expected_image)
+    for key, original_values in original_header.items():
+        np.testing.assert_array_equal(window.model.header[key], original_values)
+
+
+def test_sort_reorders_plotted_image_descending(view_with_data):
+    """Descending sort should reorder the plotted image."""
+    window = view_with_data
+    expected_indices = np.lexsort([-window.model.header["receiver_number"]])
+    expected_image = window.model.data[expected_indices, :]
+
+    window.ctrl.sort(["!receiver_number"])
+
+    np.testing.assert_array_equal(window.ctrl.trace_indices, expected_indices)
+    np.testing.assert_array_equal(window.imageItem_seismic.image, expected_image)
+
+
 class _FakeSR:
     """Minimal stand-in for spikeglx.Reader, exposing only what the jump logic reads."""
 

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -596,13 +596,15 @@ class Controller(abc.ABC):
         strip_keys = [key.lstrip("!") for key in keys]
         if not (set(strip_keys).issubset(set(self.model.header.keys()))):
             return
-        if len(keys) == 0:
+        if len(strip_keys) == 0:
             return
 
         to_sort = []
         for key, strip_key in zip(keys, strip_keys, strict=True):
-            invert = -1 if key[0] == "!" else 1
-            to_sort.append(invert * self.model.header[strip_key])
+            data = self.model.header[strip_key]
+            if key[0] == "!":
+                data = -data  # must copy here
+            to_sort.append(data)
 
         self.trace_indices = np.lexsort(to_sort)
         if redraw:

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -585,10 +585,10 @@ class Controller(abc.ABC):
 
     def sort(self, keys, redraw=True):
         """
-        Sort the channels based on the keys, which should match
-        the header.
+        Sort the channels based on the passed keys, which should
+        match the entries in the header.
 
-        A "!" can be placed before the key to indicate descending sorting
+        A "!" can be placed before the key for descending sorting
         (lexsort only supports ascending sorting). For example,
         sort(["x"]) will sort by "x" ascending, sort(["!x"]) will sort descending.
         Note this assumes no header begins with "!".
@@ -603,7 +603,7 @@ class Controller(abc.ABC):
         for key, strip_key in zip(keys, strip_keys, strict=True):
             data = self.model.header[strip_key]
             if key[0] == "!":
-                data = -data  # must copy here
+                data = -data  # must copy here to not overwrite model header
             to_sort.append(data)
 
         self.trace_indices = np.lexsort(to_sort)

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -593,7 +593,7 @@ class Controller(abc.ABC):
         sort(["x"]) will sort by "x" ascending, sort(["!x"]) will sort descending.
         Note this assumes no header begins with "!".
         """
-        strip_keys = [key.lstrip("!") for key in keys]
+        strip_keys = [key.removeprefix("!") for key in keys]
         if not (set(strip_keys).issubset(set(self.model.header.keys()))):
             return
         if len(strip_keys) == 0:

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -584,11 +584,27 @@ class Controller(abc.ABC):
         self.view.grab().save(str(file))
 
     def sort(self, keys, redraw=True):
-        if not (set(keys).issubset(set(self.model.header.keys()))):
+        """
+        Sort the channels based on the keys, which should match
+        the header.
+
+        A "!" can be placed before the key to indicate descending sorting
+        (lexsort only supports ascending sorting). For example,
+        sort(["x"]) will sort by "x" ascending, sort(["!x"]) will sort descending.
+        Note this assumes no header begins with "!".
+        """
+        strip_keys = [key.lstrip("!") for key in keys]
+        if not (set(strip_keys).issubset(set(self.model.header.keys()))):
             return
         if len(keys) == 0:
             return
-        self.trace_indices = np.lexsort([self.model.header[k] for k in keys])
+
+        to_sort = []
+        for key, strip_key in zip(keys, strip_keys, strict=True):
+            invert = -1 if key[0] == "!" else 1
+            to_sort.append(invert * self.model.header[strip_key])
+
+        self.trace_indices = np.lexsort(to_sort)
         if redraw:
             self.redraw()
 


### PR DESCRIPTION
This PR adds the option to sort in descending order for the viewer.sort function. I needed this in the spikeinterface PR as by default the larger x-valued contact was displayed before the smaller one, and there was no way to resort these as lexsort is always ascending.

This adds the assumption that no header entry starts with a "!". I think this is fairly safe but an assert can be added somewhere, but I wasn’t sure where the best place to check this was.