### PR TITLE
Update mainwindow and tests.

### DIFF
--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -166,15 +166,11 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         The slider thumb is moved to the nearest chunk for visual feedback only.
         """
         text = self.lineEdit_jumpTime.text().strip()
-        if not hasattr(self, "sr"):
-            return
-        if text == "":
-            self._update_time_label()
+        if text == "" or not hasattr(self, "sr"):
             return
         try:
             t = float(text)
         except ValueError:
-            self._update_time_label()
             return
         requested_sample = int(round(t * self.sr.fs))
         requested_sample = max(0, min(requested_sample, int(self.sr.ns) - 1))

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -76,8 +76,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         validator.setLocale(QtCore.QLocale.c())
         self.lineEdit_jumpTime.setValidator(validator)
         self.lineEdit_jumpTime.returnPressed.connect(self.on_jumpToTimeRequested)
-        self.pushButton_jumpTime.clicked.connect(self.on_jumpToTimeRequested)
         self.label_smin.setText("0")
+        self._update_time_label()
         self.show()
 
         self.viewers: dict[str, EphysViewer | None]
@@ -146,7 +146,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self._first_sample = 0
         self.horizontalSlider.setEnabled(True)
         self.lineEdit_jumpTime.setEnabled(True)
-        self.pushButton_jumpTime.setEnabled(True)
+        self._update_time_label()
         self.on_horizontalSliderReleased()
 
     def on_horizontalSliderValueChanged(self) -> None:
@@ -154,8 +154,11 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self._update_time_label()
 
     def _update_time_label(self) -> None:
+        if not hasattr(self, "sr"):
+            self.lineEdit_jumpTime.setText("0.000000")
+            return
         tcur = self._first_sample / self.sr.fs
-        self.label_sval.setText(f"{tcur:0.6f}s")
+        self.lineEdit_jumpTime.setText(f"{tcur:0.6f}")
 
     def on_jumpToTimeRequested(self) -> None:
         """Jump to the user-typed time, centering the loaded window on it.
@@ -163,11 +166,15 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         The slider thumb is moved to the nearest chunk for visual feedback only.
         """
         text = self.lineEdit_jumpTime.text().strip()
-        if text == "" or not hasattr(self, "sr"):
+        if not hasattr(self, "sr"):
+            return
+        if text == "":
+            self._update_time_label()
             return
         try:
             t = float(text)
         except ValueError:
+            self._update_time_label()
             return
         requested_sample = int(round(t * self.sr.fs))
         requested_sample = max(0, min(requested_sample, int(self.sr.ns) - 1))

--- a/src/viewephys/nav_file.ui
+++ b/src/viewephys/nav_file.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>785</width>
-    <height>295</height>
+    <height>297</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,183 +18,275 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="4" column="0">
-     <widget class="QSlider" name="horizontalSlider">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QFrame" name="frame">
-      <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
-      </property>
-      <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Dataset Info</string>
+    <item row="0" column="0" colspan="3">
+     <widget class="QWidget" name="widget_2" native="true">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
+         <property name="title">
+          <string>Select recording</string>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QCheckBox" name="cb_raw_ap">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>raw</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cb_butterworth_ap">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>AP band (high-pass 300Hz)</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cb_butterworth_lf">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>LF broadband (high-pass 2 Hz)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cb_destripe_ap">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>AP band Destriped</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
-       <item>
-        <widget class="QCheckBox" name="cb_raw_ap">
-         <property name="text">
-          <string>raw</string>
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cb_butterworth_ap">
-         <property name="text">
-          <string>AP band (high-pass 300Hz)</string>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
          </property>
-         <property name="checked">
-          <bool>true</bool>
+         <property name="title">
+          <string>Dataset info</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cb_butterworth_lf">
-         <property name="text">
-          <string>LF broadband (high-pass 2 Hz)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cb_destripe_ap">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>AP band Destriped</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Dataset Info</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
      </widget>
     </item>
-    <item row="5" column="0">
-     <widget class="QFrame" name="frame_2">
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>40</height>
-       </size>
+    <item row="5" column="0" rowspan="2" colspan="3">
+     <widget class="QGroupBox" name="groupBox_2">
+      <property name="font">
+       <font>
+        <weight>75</weight>
+        <bold>true</bold>
+       </font>
       </property>
-      <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+      <property name="title">
+       <string>Navigate time</string>
       </property>
-      <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QLabel" name="label_smin">
-         <property name="text">
-          <string>smin</string>
-         </property>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>0</number>
+       </property>
+       <item row="1" column="0" colspan="2">
+        <widget class="QWidget" name="widget" native="true">
+         <layout class="QGridLayout" name="gridLayout_6">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="1">
+           <widget class="QSlider" name="horizontalSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_smin">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Start time (s)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_smax">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>End time (s)</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
-       <item>
-        <widget class="QLabel" name="label_sval">
-         <property name="text">
-          <string>sval</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_smax">
-         <property name="text">
-          <string>smax</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item row="6" column="0">
-     <widget class="QFrame" name="frame_3">
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>40</height>
-       </size>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
-      </property>
-      <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_jumpTime">
-       <item>
-        <widget class="QLabel" name="label_jumpTime">
-         <property name="text">
-          <string>Jump to:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="lineEdit_jumpTime">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
+       <item row="3" column="0" colspan="2">
+        <widget class="QFrame" name="frame_2">
          <property name="maximumSize">
           <size>
-           <width>120</width>
-           <height>16777215</height>
+           <width>16777215</width>
+           <height>40</height>
           </size>
          </property>
-         <property name="placeholderText">
-          <string>seconds</string>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
          </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="3">
+           <spacer name="horizontalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="0">
+           <spacer name="horizontalSpacer_jumpTime">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLineEdit" name="lineEdit_jumpTime">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>120</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="placeholderText">
+             <string>seconds</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_2">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Slider value (s):</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_jumpTime">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Go</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_jumpTime">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/viewephys/nav_file.ui
+++ b/src/viewephys/nav_file.ui
@@ -98,7 +98,7 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="groupBox_dataset">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>1</horstretch>

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -151,7 +151,6 @@ def jump_window(qtbot, monkeypatch):
     window.horizontalSlider.setMaximum(slider_max)
     window.horizontalSlider.setEnabled(True)
     window.lineEdit_jumpTime.setEnabled(True)
-    window.pushButton_jumpTime.setEnabled(True)
     monkeypatch.setattr(
         window, "on_horizontalSliderReleased", lambda center_time=None: None
     )
@@ -186,7 +185,7 @@ def test_jump_to_time_loads_exact_sample(jump_window, qtbot, typed_seconds):
 
     assert window._first_sample == expected_first
     assert window.horizontalSlider.value() == expected_slider
-    assert window.label_sval.text() == f"{expected_t:0.6f}s"
+    assert window.lineEdit_jumpTime.text() == f"{expected_t:0.6f}"
 
 
 def test_jump_to_time_non_chunk_aligned(jump_window, qtbot):
@@ -199,7 +198,7 @@ def test_jump_to_time_non_chunk_aligned(jump_window, qtbot):
     assert window._first_sample + NSAMP_CHUNK // 2 == requested_sample
     assert window._first_sample == 14_999_500
     assert window.horizontalSlider.value() == 1500
-    assert window.label_sval.text() == "499.983333s"
+    assert window.lineEdit_jumpTime.text() == "499.983333"
 
 
 def test_slider_drag_resets_first_sample_to_chunk(jump_window, qtbot):
@@ -213,7 +212,9 @@ def test_slider_drag_resets_first_sample_to_chunk(jump_window, qtbot):
 
     window.horizontalSlider.setValue(1501)
     assert window._first_sample == 1501 * NSAMP_CHUNK
-    assert window.label_sval.text() == f"{1501 * NSAMP_CHUNK / window.sr.fs:0.6f}s"
+    assert window.lineEdit_jumpTime.text() == (
+        f"{1501 * NSAMP_CHUNK / window.sr.fs:0.6f}"
+    )
 
 
 def test_jump_to_time_clamps_out_of_range(jump_window, qtbot):


### PR DESCRIPTION
This PR reorganizes the main window a little, mostly for aesthetics but a slight functional reorganisation - the 'jump to' lineedit and button have been merged with the 'sval'. Now the slider value is displayed directly in the lineedit and the desired time can be entered into the lineedit, on pressing 'enter' it will go to the slider value.

The new organisation is below:

<img width="780" height="324" alt="image" src="https://github.com/user-attachments/assets/fbed76ca-2e6f-4f7a-8083-a5123ddd463c" />

This is mostly a suggestion PR as is largely a cosmetic change!