### PR TITLE
Fix header plots not flush with seismic display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@
 - `examples/` folder with `from_binary.py` and `from_array.py` demonstrating script usage ([#29](https://github.com/int-brain-lab/viewephys/pull/29), thanks @JoeZiminski)
 - README expanded with script-usage instructions showing the `create_app()` / `app.exec()` pattern
 - `spikeinterface` added as a dependency
+- `SpikeGLXDataModel` interface layer decouples data access from the viewer, laying the groundwork for a future SpikeInterface backend ([#30](https://github.com/int-brain-lab/viewephys/pull/30), thanks @JoeZiminski)
+- Channels can now be sorted in descending order by prefixing the sort key with `!` (e.g. `"!depth"`); `lexsort` only supports ascending order, so the key values are negated before sorting ([#32](https://github.com/int-brain-lab/viewephys/pull/32), thanks @JoeZiminski)
+
+### changed
+- EphysBinViewer main window reorganised: the separate "Jump to" field has been merged into the slider value lineedit — the current sample is shown there directly and typing a time then pressing Enter navigates to that position ([#38](https://github.com/int-brain-lab/viewephys/pull/38), thanks @JoeZiminski)
 
 ### fixed
 - Pick-spikes auto-detect window now scales with the current zoom level instead of using a fixed half-second range, preventing false `out_of_time_range` rejections at high sample rates ([#28](https://github.com/int-brain-lab/viewephys/pull/28), thanks @JoeZiminski)
 - `QSettings.value()` cast to `int` for `nfft`/`nperseg` in `ImShowSpectrogram` to avoid `TypeError` on `//` operator ([#28](https://github.com/int-brain-lab/viewephys/pull/28))
+- Duplicate `groupBox` widget name in `nav_file.ui` that caused a Qt warning on startup
+- Header plots are now flush with the seismic display: the vertical header's bottom axis is given an empty label so it reserves the same height as the seismic's "Time (s)" label, keeping the two ViewBoxes vertically aligned ([#43](https://github.com/int-brain-lab/viewephys/issues/43))
 
 ## [1.2.0] - 2026-04-30
 

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -183,6 +183,9 @@ class EasyQC(QtWidgets.QMainWindow, Ui_MainWindow):
 
         # Keep the top strip x-linked, but hide its duplicate x-axis.
         self.plotItem_header_h.getPlotItem().hideAxis("bottom")
+        # Give the right-side header the same label height as the seismic bottom axis
+        # so its ViewBox stays flush with the seismic display.
+        self.plotItem_header_v.getAxis("bottom").setLabel(" ")
 
         self.hoverPlotWidgets = {"Trace": None, "Spectrum": None, "Spectrogram": None}
         scene = self.viewBox_seismic.scene()


### PR DESCRIPTION
Closes #43.

## Root cause

PR #38 added a `"Time (s)"` label to `plotItem_seismic`'s bottom axis. `plotItem_header_v` and `plotItem_seismic` share the same grid row, so their ViewBoxes must have matching top and bottom axis heights to stay vertically aligned. The labelled bottom axis on the seismic plot is taller than the unlabelled bottom axis on the vertical header, shifting the two ViewBoxes out of alignment.

## Fix

One line in `EasyQC.__init__`:

```python
self.plotItem_header_v.getAxis("bottom").setLabel(" ")
```

An empty label forces pyqtgraph to reserve the same font-height row for the label area, making the two bottom axes the same total height.

## Also

Backfills CHANGELOG entries for PRs #30, #32, and #38, which were merged without updating the changelog.