### PR TITLE
Add LFPack (lfpack HDF5) backend to viewephys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 
 [project.optional-dependencies]
+lfpack = ["lfpack", "iblatlas"]  # HDF5-packed LFP files; drags in h5py + PyWavelets
 dev = [
   "pytest",
   "pytest-qt",

--- a/src/viewephys/command_line.py
+++ b/src/viewephys/command_line.py
@@ -24,16 +24,29 @@ def viewephys():
         "-f",
         "--file",
         default=None,
-        help="path to the binary file to load",
+        help="path to the binary or lfpack .h5 file to load",
         required=False,
+    )
+    parser.add_argument(
+        "--lfpack",
+        action="store_true",
+        help="open the lfpack HDF5 viewer (auto-selected for .h5/.hdf5 files)",
     )
     args = parser.parse_args()  # returns data from the options specified (echo)
     print(args.file)
-    from viewephys.gui import EphysBinViewer
+    from pathlib import Path
+
+    from viewephys.gui import EphysBinViewer, LFPackBinViewer
     from viewephys.viewer.qt import create_app
 
     app = create_app()
-    self = EphysBinViewer(args.file)  # noqa
+    # lfpack HDF5 archives need the LFPack-aware viewer; binaries use the base one.
+    is_h5 = args.file is not None and Path(args.file).suffix.lower() in (
+        ".h5",
+        ".hdf5",
+    )
+    ViewerClass = LFPackBinViewer if (args.lfpack or is_h5) else EphysBinViewer
+    self = ViewerClass(args.file)  # noqa
     sys.exit(app.exec())
 
 

--- a/src/viewephys/data_model.py
+++ b/src/viewephys/data_model.py
@@ -48,6 +48,14 @@ class AbstractDataModel(abc.ABC):
     @abc.abstractmethod
     def get_steps(self) -> list[str]: ...
 
+    def get_brain_regions(self) -> object | None:
+        """Return an ``iblatlas`` ``BrainRegions`` for atlas coloring, if any.
+
+        Defaults to ``None`` (no brain-region annotations); backends that carry
+        per-channel ``atlas_id`` in their header override this.
+        """
+        return None
+
 
 class SpikeGLXDataModel(AbstractDataModel):
     """Data model wrapping ``spikeglx.Reader``."""
@@ -179,6 +187,72 @@ class SpikeGLXDataModel(AbstractDataModel):
     def get_saturation_adc(self) -> float | None:
         """ADC saturation level in µV."""
         return self.sr.range_volts[0] * 1e6
+
+
+class LFPackDataModel(SpikeGLXDataModel):
+    """Data model for lfpack HDF5-packed LFP files.
+
+    Wraps an ``lfpack.LFPackReader`` (a drop-in ``spikeglx.Reader``).  The data
+    stored in the archive is already decompressed and denoised, so there is a
+    single ``"raw"`` step and no preprocessing branches.  Most methods are
+    inherited from :class:`SpikeGLXDataModel`; only the handful that rely on
+    SpikeGLX metadata absent from compressed files are overridden.
+    """
+
+    @override
+    def get_steps(self) -> list[str]:
+        """Single denoised signal — no preprocessing options."""
+        return ["raw"]
+
+    @override
+    def get_probe_information(self) -> str:
+        return "Neuropixels LFP (lfpack)"
+
+    @override
+    def get_saturation_adc(self) -> None:
+        """No ADC saturation level: compressed files carry no voltage range."""
+        return None
+
+    @property
+    def _channels(self) -> dict:
+        """Per-channel info from the file, read once and cached.
+
+        Static per recording, so a single read backs both the header and the
+        brain-region lookup (a new model is built when the recording changes).
+        """
+        if getattr(self, "_channels_cache", None) is None:
+            self._channels_cache = self.sr.channels_full
+        return self._channels_cache
+
+    @override
+    def get_header(self) -> dict:
+        """Probe geometry plus brain-region annotations when present.
+
+        Adds ``atlas_id`` (and ``acronym``) from the file's per-channel
+        annotations so the viewer can draw a brain-region strip.  ``acronym``
+        is returned as an ndarray so it indexes like the numeric header fields.
+        """
+        header = dict(self.sr.geometry)
+        if "atlas_id" in self._channels:
+            header["atlas_id"] = np.asarray(self._channels["atlas_id"])
+        if "acronym" in self._channels:
+            header["acronym"] = np.asarray(self._channels["acronym"])
+        return header
+
+    @override
+    def get_brain_regions(self) -> object | None:
+        """BrainRegions instance when the file carries ``atlas_id``, else None.
+
+        The (moderately expensive) ``BrainRegions`` object is built lazily on
+        first use and cached for the lifetime of the model.
+        """
+        if "atlas_id" not in self._channels:
+            return None
+        if getattr(self, "_brain_regions", None) is None:
+            from iblatlas.regions import BrainRegions
+
+            self._brain_regions = BrainRegions()
+        return self._brain_regions
 
 
 class SpikeInterfaceDataModel(AbstractDataModel):

--- a/src/viewephys/data_model.py
+++ b/src/viewephys/data_model.py
@@ -193,16 +193,36 @@ class LFPackDataModel(SpikeGLXDataModel):
     """Data model for lfpack HDF5-packed LFP files.
 
     Wraps an ``lfpack.LFPackReader`` (a drop-in ``spikeglx.Reader``).  The data
-    stored in the archive is already decompressed and denoised, so there is a
-    single ``"raw"`` step and no preprocessing branches.  Most methods are
-    inherited from :class:`SpikeGLXDataModel`; only the handful that rely on
-    SpikeGLX metadata absent from compressed files are overridden.
+    is already decompressed and denoised, so the steps are the ``"raw"`` signal
+    and its current-source density (``"csd"``).  Most methods are inherited from
+    :class:`SpikeGLXDataModel`; only those relying on SpikeGLX metadata absent
+    from compressed files, or specific to lfpack, are overridden.
     """
 
     @override
     def get_steps(self) -> list[str]:
-        """Single denoised signal — no preprocessing options."""
-        return ["raw"]
+        """Denoised signal and its current-source density."""
+        return ["raw", "csd"]
+
+    @override
+    def get_data(
+        self,
+        start_sample: int,
+        end_sample: int,
+        step: str,
+        raw: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Return the raw signal or its current-source density.
+
+        The ``"csd"`` step computes the CSD via
+        :func:`ibldsp.voltage.current_source_density`; other steps defer to the
+        inherited (raw pass-through) implementation.
+        """
+        if step != "csd":
+            return super().get_data(start_sample, end_sample, step, raw=raw)
+        if raw is None:
+            raw = self.get_raw(start_sample, end_sample)
+        return voltage.current_source_density(raw, h=self.get_header())
 
     @override
     def get_probe_information(self) -> str:
@@ -228,11 +248,14 @@ class LFPackDataModel(SpikeGLXDataModel):
     def get_header(self) -> dict:
         """Probe geometry plus brain-region annotations when present.
 
-        Adds ``atlas_id`` (and ``acronym``) from the file's per-channel
-        annotations so the viewer can draw a brain-region strip.  ``acronym``
-        is returned as an ndarray so it indexes like the numeric header fields.
+        Adds ``col``/``row`` (derived from ``x``/``y``) so the CSD step has the
+        column/row layout it needs, and ``atlas_id``/``acronym`` from the file's
+        per-channel annotations so the viewer can draw a brain-region strip.
+        ``acronym`` is an ndarray so it indexes like the numeric header fields.
         """
         header = dict(self.sr.geometry)
+        _, header["col"] = np.unique(np.asarray(header["x"]), return_inverse=True)
+        _, header["row"] = np.unique(np.asarray(header["y"]), return_inverse=True)
         if "atlas_id" in self._channels:
             header["atlas_id"] = np.asarray(self._channels["atlas_id"])
         if "acronym" in self._channels:

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -17,7 +17,11 @@ from iblutil.numerical import ismember
 from neuropixel import trace_header
 from qtpy import QtCore, QtGui, QtWidgets, uic
 
-from viewephys.data_model import SpikeGLXDataModel, SpikeInterfaceDataModel
+from viewephys.data_model import (
+    LFPackDataModel,
+    SpikeGLXDataModel,
+    SpikeInterfaceDataModel,
+)
 from viewephys.viewer.gui import EasyQC
 from viewephys.viewer.qt import create_app
 
@@ -105,6 +109,9 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         """
         self.open_file(*args, live=True, **kwargs)
 
+    # File-dialog filter; subclasses widen it to expose more formats.
+    FILE_FILTER = "Electrophysiology files (*.*bin *.dat)"
+
     def open_file(
         self, *args, live: bool = False, file: str | Path | None = None
     ) -> None:
@@ -119,7 +126,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                 parent=self,
                 caption="Select Raw electrophysiology recording",
                 directory=self.settings.value("bin_file_path"),
-                filter="Electrophysiology files (*.*bin *.dat)",
+                filter=self.FILE_FILTER,
             )
             if file == "":
                 return
@@ -127,18 +134,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         if isinstance(file, (str, Path)):
             file = Path(file)
             self.settings.setValue("bin_file_path", str(file.parent))
-            ReaderClass = spikeglx.Reader if not live else spikeglx.OnlineReader
-            try:
-                sr = ReaderClass(file)
-            except AssertionError:
-                sr = spikeglx.Reader(
-                    file,
-                    dtype="int16",
-                    nc=384,
-                    fs=30000,
-                    ns=file.stat().st_size / 384 / 2,
-                )
-            self.data = SpikeGLXDataModel(sr)
+            self._open_path(file, live=live)
 
         elif isinstance(file, dict):
             self.data = SpikeInterfaceDataModel(file)
@@ -148,6 +144,25 @@ class EphysBinViewer(QtWidgets.QMainWindow):
 
         self._setup_viewers_and_checkboxes()
         self._setup_slider()
+
+    def _open_path(self, file: Path, live: bool = False) -> None:
+        """Build ``self.data`` from a file path.
+
+        Base implementation reads SpikeGLX binaries; subclasses override to
+        handle additional formats and fall back to ``super()`` for binaries.
+        """
+        ReaderClass = spikeglx.Reader if not live else spikeglx.OnlineReader
+        try:
+            sr = ReaderClass(file)
+        except AssertionError:
+            sr = spikeglx.Reader(
+                file,
+                dtype="int16",
+                nc=384,
+                fs=30000,
+                ns=file.stat().st_size / 384 / 2,
+            )
+        self.data = SpikeGLXDataModel(sr)
 
     def _setup_slider(self):
         num_samples = self.data.get_num_samples()
@@ -182,41 +197,38 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         """Repopulate viewers/cbs based on the current data model."""
         self.viewers: dict[str, EphysViewer | None]
 
-        if isinstance(self.data, SpikeGLXDataModel):
-            # If SpikeGLXDataModel is used, then offer the
-            # preprocessing options from the IBL
-            self.viewers = {
-                "butterworth": None,
-                "destripe": None,
-                "raw": None,
-                "broadband": None,
-            }
-            self.cbs = {
-                "butterworth": self.cb_butterworth_ap,
-                "broadband": self.cb_butterworth_lf,
-                "destripe": self.cb_destripe_ap,
-                "raw": self.cb_raw_ap,
-            }
+        # Pre-built descriptive checkboxes for the IBL SpikeGLX pipeline.
+        ibl_cbs = {
+            "raw": self.cb_raw_ap,
+            "butterworth": self.cb_butterworth_ap,
+            "broadband": self.cb_butterworth_lf,
+            "destripe": self.cb_destripe_ap,
+        }
+        # Clear any dynamic checkboxes added on a previous open (e.g. switching
+        # recording in a multi-recording lfpack file).
+        for cb in getattr(self, "_dynamic_cbs", []):
+            cb.setParent(None)
+            cb.deleteLater()
+        self._dynamic_cbs = []
+
+        steps = self.data.get_steps()
+        self.viewers = dict.fromkeys(steps)
+        if set(steps) == set(ibl_cbs):
+            # IBL SpikeGLX pipeline: reuse the descriptive checkboxes from the .ui
+            self.cbs = {step: ibl_cbs[step] for step in steps}
         else:
-            # Otherwise, if the data is a dict of spikeinterface
-            # recordings, hide the existing checkboxes and
-            # populate with the recording dict keys defined by the user
-            for cb in [
-                self.cb_raw_ap,
-                self.cb_butterworth_ap,
-                self.cb_butterworth_lf,
-                self.cb_destripe_ap,
-            ]:
+            # Any other model (SpikeInterface, lfpack, …): hide the pre-built
+            # checkboxes and build one checkbox per step returned by get_steps().
+            for cb in ibl_cbs.values():
                 cb.hide()
             layout = self.select_recording_groupbox.layout()
-            self.viewers = {}
             self.cbs = {}
-            for i, step in enumerate(self.data.get_steps()):
+            for i, step in enumerate(steps):
                 cb = QtWidgets.QCheckBox(step, self.select_recording_groupbox)
                 cb.setChecked(i == 0)
                 layout.addWidget(cb)
-                self.viewers[step] = None
                 self.cbs[step] = cb
+                self._dynamic_cbs.append(cb)
 
     def _create_top_label(self):
         """Create the label of recording details shown on the main window."""
@@ -372,6 +384,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
                 data,
                 self.data.get_sampling_frequency(),
                 channels=self.data.get_header(),
+                br=self.data.get_brain_regions(),
                 title=k,
                 t0=t0 * T_SCALAR,
                 t_scalar=T_SCALAR,
@@ -414,11 +427,115 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         TODO: if we set the EphysViewer windows as children of
         this window, Qt will automatically handle the window close.
         """
-        for k in self.viewers:
-            ev = self.viewers[k]
+        # self.viewers only exists once a file has been opened.
+        for ev in getattr(self, "viewers", {}).values():
             if ev is not None:
                 ev.close()
         self.close()
+
+
+class LFPackBinViewer(EphysBinViewer):
+    """Ephys viewer for lfpack HDF5-packed LFP files.
+
+    Extends :class:`EphysBinViewer` with support for the ``.h5`` archives
+    produced by ``lfpack``.  A file may hold a single recording or many keyed
+    by probe-insertion UUID; in the latter case a searchable combo box lets the
+    user switch recording.  SpikeGLX binaries still open through the inherited
+    machinery, so a single window handles both formats.
+    """
+
+    FILE_FILTER = "Electrophysiology files (*.*bin *.dat *.h5 *.hdf5)"
+
+    def _open_path(self, file: Path, live: bool = False) -> None:
+        if file.suffix.lower() in (".h5", ".hdf5"):
+            self._open_lfpack(file)
+        else:
+            self._hide_recording_selector()
+            super()._open_path(file, live=live)
+
+    def _open_lfpack(self, file: Path) -> None:
+        """Open an lfpack HDF5 file, wiring up the recording selector.
+
+        A file may hold a single recording (opened directly) or many keyed by
+        probe-insertion UUID, in which case a searchable selector is shown and
+        the first recording is opened.
+        """
+        try:
+            import lfpack
+        except ImportError as e:
+            raise ImportError(
+                "Reading lfpack HDF5 files requires the optional 'lfpack' "
+                "dependency. Install it with: pip install viewephys[lfpack]"
+            ) from e
+
+        self._lfpack_file = file
+        recordings = lfpack.LFPackReader.recordings(file)
+        if len(recordings) > 1:
+            self._build_recording_selector(recordings)
+            recording = recordings[0]
+        else:
+            self._hide_recording_selector()
+            # An empty list means the legacy single-recording layout.
+            recording = recordings[0] if recordings else None
+
+        reader = lfpack.LFPackReader(file, recording=recording)
+        self.data = LFPackDataModel(reader)
+
+    def _build_recording_selector(self, recordings: list[str]) -> None:
+        """Show a searchable combo box to pick a recording by UUID substring."""
+        if not hasattr(self, "comboBox_recording"):
+            self.groupBox_recording = QtWidgets.QGroupBox("Recording", self.widget_2)
+            layout = QtWidgets.QVBoxLayout(self.groupBox_recording)
+            self.comboBox_recording = QtWidgets.QComboBox(self.groupBox_recording)
+            self.comboBox_recording.setEditable(True)
+            self.comboBox_recording.setInsertPolicy(
+                QtWidgets.QComboBox.InsertPolicy.NoInsert
+            )
+            completer = self.comboBox_recording.completer()
+            completer.setCompletionMode(
+                QtWidgets.QCompleter.CompletionMode.PopupCompletion
+            )
+            completer.setFilterMode(QtCore.Qt.MatchFlag.MatchContains)
+            completer.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
+            layout.addWidget(self.comboBox_recording)
+            # Sits next to the "Select recording" / "Dataset info" group boxes.
+            self.widget_2.layout().addWidget(self.groupBox_recording, 0, 2)
+            self.comboBox_recording.activated.connect(self._on_recording_selected)
+
+        combo = self.comboBox_recording
+        combo.blockSignals(True)
+        combo.clear()
+        combo.addItems(recordings)
+        combo.setCurrentIndex(0)
+        combo.blockSignals(False)
+        self.groupBox_recording.show()
+
+    def _hide_recording_selector(self) -> None:
+        """Hide the recording selector if it was built for a previous file."""
+        if hasattr(self, "groupBox_recording"):
+            self.groupBox_recording.hide()
+
+    def _on_recording_selected(self, index: int) -> None:
+        """Swap in the chosen recording, keeping the window size, position and zoom."""
+        import lfpack
+
+        recording = self.comboBox_recording.itemText(index)
+        reader = lfpack.LFPackReader(self._lfpack_file, recording=recording)
+        self.data = LFPackDataModel(reader)
+
+        # Refresh slider bounds and clamp position into range; keep window and zoom.
+        self.update_slider_limits()
+        max_first = max(0, self.data.get_num_samples() - self.window_length_n)
+        self._first_sample = min(self._first_sample, max_first)
+        slider_value = min(
+            int(round(self._first_sample / self.window_length_n)),
+            self.horizontalSlider.maximum(),
+        )
+        self.horizontalSlider.blockSignals(True)
+        self.horizontalSlider.setValue(slider_value)
+        self.horizontalSlider.blockSignals(False)
+        self._update_time_label()
+        self.on_horizontalSliderReleased()
 
 
 class PickSpikes:

--- a/src/viewephys/tests/test_data_model.py
+++ b/src/viewephys/tests/test_data_model.py
@@ -92,8 +92,8 @@ class TestLFPackDataModel:
         reader = lfpack.LFPackReader(h5)
         model = LFPackDataModel(reader)
 
-        # A packed file exposes a single, already-denoised signal.
-        assert model.get_steps() == ["raw"]
+        # A packed file exposes the denoised signal and its CSD.
+        assert model.get_steps() == ["raw", "csd"]
         assert model.get_num_channels() == 64
         assert model.get_sampling_frequency() == 250.0
         assert model.get_num_samples() == 6000
@@ -117,6 +117,13 @@ class TestLFPackDataModel:
         raw = model.get_raw(0, 100)
         assert raw.shape == (64, 100)
         assert np.array_equal(model.get_data(0, 100, "raw", raw=raw), raw)
+
+        # The CSD step returns a finite array of the same shape as the signal.
+        csd = model.get_data(0, 500, "csd")
+        assert csd.shape == (64, 500)
+        assert np.isfinite(csd).all()
+        # Header carries col/row so current_source_density has the layout.
+        assert "col" in header and "row" in header
 
     def test_no_annotations_has_no_brain_regions(self, tmp_path):
         lfpack = pytest.importorskip("lfpack")

--- a/src/viewephys/tests/test_data_model.py
+++ b/src/viewephys/tests/test_data_model.py
@@ -9,7 +9,12 @@ from ibldsp import voltage
 from numpy.testing import assert_equal as np_assert_equal
 from spikeglx import Reader, _mock_spikeglx_file
 
-from viewephys.data_model import SpikeGLXDataModel, SpikeInterfaceDataModel
+from viewephys.data_model import (
+    LFPackDataModel,
+    SpikeGLXDataModel,
+    SpikeInterfaceDataModel,
+)
+from viewephys.tests.test_viewer_helpers import build_lfpack_h5
 
 
 class TestSpikeGLXDataModel:
@@ -77,6 +82,87 @@ class TestSpikeGLXDataModel:
 
         # Filtering alone is not tested.
         assert model.get_steps() == ["raw", "butterworth", "destripe", "broadband"]
+
+
+class TestLFPackDataModel:
+    def test_single_recording(self, tmp_path):
+        lfpack = pytest.importorskip("lfpack")
+        h5 = build_lfpack_h5(tmp_path / "lf.h5", "uuid-aaaa", nc=64, ns=6000)
+
+        reader = lfpack.LFPackReader(h5)
+        model = LFPackDataModel(reader)
+
+        # A packed file exposes a single, already-denoised signal.
+        assert model.get_steps() == ["raw"]
+        assert model.get_num_channels() == 64
+        assert model.get_sampling_frequency() == 250.0
+        assert model.get_num_samples() == 6000
+        assert model.get_recording_length() == pytest.approx(6000 / 250.0)
+        assert model.get_probe_information() == "Neuropixels LFP (lfpack)"
+        # No ADC saturation / voltage range in compressed files.
+        assert model.get_saturation_adc() is None
+        assert model.get_file_path() == h5
+
+        # Probe geometry is available as the trace header.
+        header = model.get_header()
+        assert "x" in header and "y" in header
+        assert header["x"].size == 64
+
+        # Data comes back channel-first, in volts.
+        data = model.get_data(0, 500, "raw")
+        assert data.shape == (64, 500)
+        assert data.dtype == np.float32
+
+        # get_data passes a pre-fetched raw buffer straight through.
+        raw = model.get_raw(0, 100)
+        assert raw.shape == (64, 100)
+        assert np.array_equal(model.get_data(0, 100, "raw", raw=raw), raw)
+
+    def test_no_annotations_has_no_brain_regions(self, tmp_path):
+        lfpack = pytest.importorskip("lfpack")
+        h5 = build_lfpack_h5(tmp_path / "lf.h5", "uuid-aaaa", nc=32, ns=4096)
+        model = LFPackDataModel(lfpack.LFPackReader(h5))
+
+        header = model.get_header()
+        assert "atlas_id" not in header
+        assert model.get_brain_regions() is None
+
+    def test_channel_annotations_and_brain_regions(self, tmp_path):
+        lfpack = pytest.importorskip("lfpack")
+        pytest.importorskip("iblatlas")
+        h5 = build_lfpack_h5(
+            tmp_path / "lf.h5", "uuid-aaaa", nc=32, ns=4096, annotate=True
+        )
+        model = LFPackDataModel(lfpack.LFPackReader(h5))
+
+        # Brain-region annotations flow into the channel/header table.
+        header = model.get_header()
+        assert "atlas_id" in header and "acronym" in header
+        assert header["atlas_id"].shape == (32,)
+        # acronym is an ndarray so it indexes like the numeric header fields.
+        assert isinstance(header["acronym"], np.ndarray)
+
+        # A single BrainRegions instance is built and reused.
+        br = model.get_brain_regions()
+        assert br is not None
+        assert hasattr(br, "id") and hasattr(br, "rgb")
+        assert model.get_brain_regions() is br
+
+    def test_recordings_listing_multi(self, tmp_path):
+        lfpack = pytest.importorskip("lfpack")
+        f1 = build_lfpack_h5(tmp_path / "a.h5", "uuid-aaaa", nc=32, ns=4096)
+        f2 = build_lfpack_h5(tmp_path / "b.h5", "uuid-bbbb", nc=32, ns=4096)
+        multi = tmp_path / "multi.h5"
+        lfpack.merge_h5([f1, f2], multi)
+
+        recordings = lfpack.LFPackReader.recordings(multi)
+        assert set(recordings) == {"uuid-aaaa", "uuid-bbbb"}
+
+        # Each recording opens into an independent, valid data model.
+        for rec in recordings:
+            model = LFPackDataModel(lfpack.LFPackReader(multi, recording=rec))
+            assert model.get_num_channels() == 32
+            assert model.get_num_samples() == 4096
 
 
 class TestSpikeInterfaceDataModel:

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -2,9 +2,18 @@ import numpy as np
 import pytest
 from qtpy import QtCore, QtWidgets
 
-from viewephys.data_model import SpikeGLXDataModel
-from viewephys.gui import A_SCALAR, EphysBinViewer, create_app, viewephys
-from viewephys.tests.test_viewer_helpers import synthetic_seismic_data
+from viewephys.data_model import LFPackDataModel, SpikeGLXDataModel
+from viewephys.gui import (
+    A_SCALAR,
+    EphysBinViewer,
+    LFPackBinViewer,
+    create_app,
+    viewephys,
+)
+from viewephys.tests.test_viewer_helpers import (
+    build_lfpack_h5,
+    synthetic_seismic_data,
+)
 from viewephys.viewer.gui import EasyQC, viewseis
 
 
@@ -442,6 +451,102 @@ def test_window_size_change_displays_different_data(qtbot):
 
     window.close()
     window.deleteLater()
+
+
+def _open_lfpack_window(qtbot, monkeypatch, file):
+    """Build an LFPackBinViewer and open a file without spawning viewers."""
+    window = LFPackBinViewer()
+    qtbot.addWidget(window)
+    # Suppress viewer spawning so tests stay light and headless-safe.
+    monkeypatch.setattr(
+        window, "on_horizontalSliderReleased", lambda center_time=None: None
+    )
+    window.open_file(file=file)
+    return window
+
+
+def test_lfpack_single_recording_opens(qtbot, monkeypatch, tmp_path):
+    """A single-recording h5 opens as an LFPackDataModel with no selector."""
+    pytest.importorskip("lfpack")
+    h5 = build_lfpack_h5(tmp_path / "lf.h5", "uuid-aaaa", nc=64, ns=6000)
+    window = _open_lfpack_window(qtbot, monkeypatch, h5)
+
+    assert isinstance(window.data, LFPackDataModel)
+    assert list(window.cbs) == ["raw"]
+    # No recording selector for single-recording files.
+    assert not (
+        hasattr(window, "groupBox_recording") and window.groupBox_recording.isVisible()
+    )
+
+    window.close()
+    window.deleteLater()
+
+
+def test_lfpack_multi_recording_selector(qtbot, monkeypatch, tmp_path):
+    """A multi-recording h5 shows the selector and can switch recording."""
+    lfpack = pytest.importorskip("lfpack")
+    f1 = build_lfpack_h5(tmp_path / "a.h5", "uuid-aaaa", nc=32, ns=4096)
+    f2 = build_lfpack_h5(tmp_path / "b.h5", "uuid-bbbb", nc=32, ns=4096)
+    multi = tmp_path / "multi.h5"
+    lfpack.merge_h5([f1, f2], multi)
+
+    window = _open_lfpack_window(qtbot, monkeypatch, multi)
+
+    assert window.groupBox_recording.isVisible()
+    combo = window.comboBox_recording
+    recs = [combo.itemText(i) for i in range(combo.count())]
+    assert set(recs) == {"uuid-aaaa", "uuid-bbbb"}
+
+    first = window.data.sr._root.split("/")[0]
+    other_index = 1 - recs.index(first)
+
+    # Switching recording must keep the window size and position, not re-init.
+    window.window_length_n = 500
+    window._first_sample = 1000
+    window._on_recording_selected(other_index)
+    assert window.data.sr._root.split("/")[0] == recs[other_index]
+    assert window.window_length_n == 500
+    assert window._first_sample == 1000
+
+    window.close()
+    window.deleteLater()
+
+
+def test_lfpack_recording_selector_searchable(qtbot, monkeypatch, tmp_path):
+    """The selector is an editable combo box with a substring completer."""
+    lfpack = pytest.importorskip("lfpack")
+    f1 = build_lfpack_h5(tmp_path / "a.h5", "abc-1111", nc=32, ns=4096)
+    f2 = build_lfpack_h5(tmp_path / "b.h5", "xyz-2222", nc=32, ns=4096)
+    multi = tmp_path / "multi.h5"
+    lfpack.merge_h5([f1, f2], multi)
+
+    window = _open_lfpack_window(qtbot, monkeypatch, multi)
+    combo = window.comboBox_recording
+    assert combo.isEditable()
+
+    completer = combo.completer()
+    assert completer.filterMode() == QtCore.Qt.MatchFlag.MatchContains
+
+    # A leading substring matches exactly one uuid.
+    completer.setCompletionPrefix("xyz")
+    assert completer.completionCount() == 1
+    # A mid-string substring also matches (MatchContains, not prefix).
+    completer.setCompletionPrefix("222")
+    assert completer.completionCount() == 1
+    # A substring present in neither uuid matches nothing.
+    completer.setCompletionPrefix("zzz-none")
+    assert completer.completionCount() == 0
+
+    window.close()
+    window.deleteLater()
+
+
+@pytest.mark.parametrize("viewer_cls", [EphysBinViewer, LFPackBinViewer])
+def test_close_without_opening_file(qtbot, viewer_cls):
+    """Closing a viewer before any file is opened must not raise."""
+    window = viewer_cls()
+    qtbot.addWidget(window)
+    window.closeEvent(None)  # no self.viewers yet
 
 
 def test_auto_downsample_true_by_default(view_with_data):

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -472,7 +472,7 @@ def test_lfpack_single_recording_opens(qtbot, monkeypatch, tmp_path):
     window = _open_lfpack_window(qtbot, monkeypatch, h5)
 
     assert isinstance(window.data, LFPackDataModel)
-    assert list(window.cbs) == ["raw"]
+    assert list(window.cbs) == ["raw", "csd"]
     # No recording selector for single-recording files.
     assert not (
         hasattr(window, "groupBox_recording") and window.groupBox_recording.isVisible()

--- a/src/viewephys/tests/test_viewer_helpers.py
+++ b/src/viewephys/tests/test_viewer_helpers.py
@@ -1,4 +1,39 @@
+from pathlib import Path
+
 import numpy as np
+
+
+def build_lfpack_h5(
+    path: Path,
+    recording: str,
+    nc: int = 64,
+    ns: int = 6000,
+    fs: float = 250.0,
+    annotate: bool = False,
+) -> Path:
+    """Write a tiny single-recording lfpack HDF5 file for tests.
+
+    Requires the optional ``lfpack`` dependency; callers should guard with
+    ``pytest.importorskip('lfpack')``.  When ``annotate`` is True, per-channel
+    brain-region annotations (``atlas_id``/``acronym``) are stored so the
+    brain-region code path can be exercised.
+    """
+    import lfpack
+
+    rng = np.random.default_rng(0)
+    data = (rng.standard_normal((ns, nc)) * 1e-5).astype(np.float32)
+    npy = Path(path).with_suffix(".cadzow.npy")
+    np.save(npy, data)
+    channels = None
+    if annotate:
+        channels = {
+            "atlas_id": np.zeros(nc, dtype=np.int32),  # 0 = root, valid in br.id
+            "acronym": ["void"] * nc,
+        }
+    lfpack.compress_to_h5(
+        npy, path, recording=recording, fs=fs, n_jobs=1, channels=channels
+    )
+    return Path(path)
 
 
 def ricker(points: int, a: float) -> np.ndarray:


### PR DESCRIPTION
## Summary
Adds an optional lfpack backend so viewephys can open lfpack HDF5-packed LFP files (`.h5`/`.hdf5`), including multi-recording archives.

## Changes
- **`LFPackDataModel`** — wraps `lfpack.LFPackReader` (a drop-in `spikeglx.Reader`); single already-denoised `raw` step. Feeds per-channel brain-region annotations (`atlas_id`/`acronym`) into the header and exposes a cached, lazily-built `BrainRegions` for atlas coloring.
- **`LFPackBinViewer(EphysBinViewer)`** — subclass owning the `.h5` file filter, suffix routing, and a searchable (substring) recording selector for multi-recording files. Switching recording preserves the window size, position and viewer zoom.
- `_setup_viewers_and_checkboxes` now selects fixed-vs-dynamic checkboxes from `get_steps()` instead of `isinstance`.
- Fix: closing a viewer before any file is opened no longer raises.
- CLI: `viewephys -f file.h5` auto-selects the lfpack viewer; `--lfpack` opens it empty.
- `lfpack` (and `iblatlas`) added as an optional `[lfpack]` dependency; imported lazily so h5py stays out of the base install.

## Tests
Data-model and Qt GUI tests (gated with `importorskip('lfpack')`) covering single/multi-recording, the searchable selector, brain-region wiring, window/zoom preservation, and the close-without-open regression.