### PR TITLE
Keep header axes synced under ctrl+P propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### fixed
+- ctrl+P propagation no longer detaches the top/side header axes: the header viewboxes are now linked *to* the seismic view instead of the reverse, freeing the seismic viewbox's single X/Y link slots for cross-window linking. Panning/zooming any linked window now keeps every window's main plot and header strips in sync
+
 ## [1.3.0] - 2026-07-07
 
 ### added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### fixed
 - ctrl+P propagation no longer detaches the top/side header axes: the header viewboxes are now linked *to* the seismic view instead of the reverse, freeing the seismic viewbox's single X/Y link slots for cross-window linking. Panning/zooming any linked window now keeps every window's main plot and header strips in sync
+- `EasyQC._instances()` now skips wrappers whose C++ object has been deleted, so window lookup and ctrl+P propagation no longer raise a `RuntimeError` when a stale window lingers
 
 ## [1.3.0] - 2026-07-07
 

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import numpy as np
 import pyqtgraph as pg
 import pytest
@@ -614,6 +616,29 @@ def test_propagate_link_keeps_headers_attached(qtbot, synthetic_seis):
     qtbot.wait(20)
     assert list(s_other.viewRange()[0]) == pytest.approx([5, 15])
     assert list(h_other.viewRange()[0]) == pytest.approx([5, 15])
+
+
+def test_instances_skips_deleted_wrappers(qtbot, monkeypatch):
+    """_instances() must skip EasyQC wrappers whose C++ object has been deleted
+    (they pass isinstance but raise RuntimeError when probed)."""
+    live = EasyQC()
+    qtbot.addWidget(live)
+
+    # Mock(spec=EasyQC) passes isinstance(EasyQC); make its probe raise as a real
+    # deleted Qt wrapper would.
+    dead = Mock(spec=EasyQC)
+    dead.objectName.side_effect = RuntimeError(
+        "wrapped C/C++ object of type EasyQC has been deleted"
+    )
+    assert isinstance(dead, EasyQC)
+
+    fake_app = Mock()
+    fake_app.topLevelWidgets.return_value = [live, dead]
+    monkeypatch.setattr(QtWidgets.QApplication, "instance", lambda: fake_app)
+
+    instances = EasyQC._instances()
+    assert live in instances
+    assert dead not in instances
 
 
 def test_auto_downsample_true_by_default(view_with_data):

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pyqtgraph as pg
 import pytest
 from qtpy import QtCore, QtWidgets
 
@@ -547,6 +548,72 @@ def test_close_without_opening_file(qtbot, viewer_cls):
     window = viewer_cls()
     qtbot.addWidget(window)
     window.closeEvent(None)  # no self.viewers yet
+
+
+def _viewbox(plot_widget):
+    return plot_widget.getPlotItem().getViewBox()
+
+
+def test_header_axes_track_seismic(view_with_data, qtbot):
+    """The header viewboxes must follow the seismic view, while the seismic's
+    own X/Y link slots stay free for cross-window propagation (ctrl+P)."""
+    window = view_with_data
+    seis = _viewbox(window.plotItem_seismic)
+    header_h = _viewbox(window.plotItem_header_h)
+    header_v = _viewbox(window.plotItem_header_v)
+
+    # Headers link *to* the seismic; the seismic keeps both slots free so ctrl+P
+    # can link it to another window without detaching the headers.
+    assert header_h.linkedView(pg.ViewBox.XAxis) is seis
+    assert header_v.linkedView(pg.ViewBox.YAxis) is seis
+    assert seis.linkedView(pg.ViewBox.XAxis) is None
+    assert seis.linkedView(pg.ViewBox.YAxis) is None
+
+    # Panning/zooming the seismic must propagate to the top (x) header strip.
+    seis.setXRange(10, 20, padding=0)
+    qtbot.wait(20)
+    assert list(header_h.viewRange()[0]) == pytest.approx([10, 20])
+
+
+def test_propagate_link_keeps_headers_attached(qtbot, synthetic_seis):
+    """The cross-window link that ctrl+P applies (Controller.propagate) must link
+    a window's seismic to the master *and* keep that window's header tracking its
+    own seismic — regression for the single-slot link overwrite that detached
+    propagated windows' headers."""
+    data, header = synthetic_seis
+
+    def _make_view():
+        # Build directly rather than via viewseis(), which scans global instances.
+        w = EasyQC()
+        w.model.set_data(data, si=0.002, header=header)
+        w.ctrl.set_model()
+        qtbot.addWidget(w)
+        w.show()
+        return w
+
+    master = _make_view()
+    other = _make_view()
+    qtbot.wait(50)
+
+    s_master = _viewbox(master.plotItem_seismic)
+    s_other = _viewbox(other.plotItem_seismic)
+    h_other = _viewbox(other.plotItem_header_h)
+
+    # Mirror the link step propagate() performs on each non-master window.
+    other.plotItem_seismic.setXLink(master.plotItem_seismic)
+    other.plotItem_seismic.setYLink(master.plotItem_seismic)
+    qtbot.wait(20)
+
+    # other's seismic now follows the master, and its header still follows its own
+    # seismic (header -> seismic -> master-seismic all chained).
+    assert s_other.linkedView(pg.ViewBox.XAxis) is s_master
+    assert h_other.linkedView(pg.ViewBox.XAxis) is s_other
+
+    # Driving the master must move the other window's seismic *and* its header.
+    s_master.setXRange(5, 15, padding=0)
+    qtbot.wait(20)
+    assert list(s_other.viewRange()[0]) == pytest.approx([5, 15])
+    assert list(h_other.viewRange()[0]) == pytest.approx([5, 15])
 
 
 def test_auto_downsample_true_by_default(view_with_data):

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -160,12 +160,17 @@ class EasyQC(QtWidgets.QMainWindow):
         self._init_cmenu()
         self.plotDataItem_header_h = pg.PlotDataItem()
         self.plotItem_header_h.addItem(self.plotDataItem_header_h)
-        self.plotItem_seismic.setXLink(self.plotItem_header_h)
+        # Link the header viewboxes *to* the seismic (rather than the reverse) so
+        # the seismic viewbox's single X/Y link slots stay free for cross-window
+        # propagation (ctrl+P). Linking is bidirectional and chains transitively, so
+        # the headers still track the seismic, and header -> seismic -> master-seismic
+        # all stay in sync.
+        self.plotItem_header_h.setXLink(self.plotItem_seismic)
         self.plotDataItem_header_v = pg.PlotDataItem()
         self.plotItem_header_h.setBackground(background_color)
         self.plotItem_header_v.addItem(self.plotDataItem_header_v)
         self.plotItem_header_v.setBackground(background_color)
-        self.plotItem_seismic.setYLink(self.plotItem_header_v)
+        self.plotItem_header_v.setYLink(self.plotItem_seismic)
         ax = self.plotItem_seismic.getAxis("left")
         ax.setStyle(
             tickTextWidth=60, autoReduceTextSpace=False, autoExpandTextSpace=False

--- a/src/viewephys/viewer/gui.py
+++ b/src/viewephys/viewer/gui.py
@@ -108,7 +108,19 @@ class EasyQC(QtWidgets.QMainWindow):
         app = QtWidgets.QApplication.instance()
         if app is None:
             app = qt.create_app()
-        return [w for w in app.topLevelWidgets() if isinstance(w, EasyQC)]
+        instances = []
+        for w in app.topLevelWidgets():
+            if not isinstance(w, EasyQC):
+                continue
+            # A wrapper whose C++ object was deleted (e.g. via deleteLater) still
+            # passes isinstance but raises RuntimeError on any method call. Probe
+            # cheaply and skip such stale wrappers so callers never touch them.
+            try:
+                w.objectName()
+            except RuntimeError:
+                continue
+            instances.append(w)
+        return instances
 
     @staticmethod
     def _get_or_create(title=None):


### PR DESCRIPTION
## Problem

The top and side header axes are linked to the main seismic view, and ctrl+P propagates the link across windows. But a pyqtgraph `ViewBox` holds only **one** linked view per axis, so calling `setXLink` twice on the same viewbox overwrites the first link.

The intra-window wiring put the link on the seismic viewbox (`seismic.setXLink(header_h)`). When `propagate()` then ran `eqc.seismic.setXLink(master.seismic)`, it clobbered that slot and **detached the propagated windows' header axes**.

## Fix

Reverse the intra-window link direction: link the header viewboxes *to* the seismic (`header_h.setXLink(seismic)`, `header_v.setYLink(seismic)`). This frees the seismic's X/Y link slots for cross-window propagation. Because linking is bidirectional and chains transitively, everything now stays in sync: `header -> seismic -> master-seismic`.

Also harden `EasyQC._instances()` (inherited by `EphysViewer`) to skip wrappers whose underlying C++ object has been deleted — these still pass `isinstance` but raise `RuntimeError` on any method call, which could surface during window lookup or ctrl+P propagation when a stale window lingered.

## Tests

- `test_header_axes_track_seismic`: header viewboxes link to the seismic, the seismic's slots stay free, and panning propagates to the header strip.
- `test_propagate_link_keeps_headers_attached`: after the cross-window link, the other window's seismic follows the master *and* its header still follows its own seismic.
- `test_instances_skips_deleted_wrappers`: `_instances()` filters out deleted wrappers instead of raising.

Full suite (53 tests) passes; ruff clean.