### PR TITLE
Support spikeinterface times.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# macOS
+.DS_Store

--- a/examples/from_spikeinterface.py
+++ b/examples/from_spikeinterface.py
@@ -14,6 +14,10 @@ raw, _sorting = si.generate_ground_truth_recording(
     num_units=10,
     seed=0,
 )
+
+# Set times so they don't start at zero
+raw.set_times(raw.get_times() + 40)
+
 highpass = spre.highpass_filter(raw, freq_min=300.0)
 
 viewer = EphysBinViewer(

--- a/src/viewephys/data_model.py
+++ b/src/viewephys/data_model.py
@@ -28,12 +28,6 @@ class AbstractDataModel(abc.ABC):
     def get_sampling_frequency(self) -> float: ...
 
     @abc.abstractmethod
-    def get_time_from_sample(self, sample: int) -> float: ...
-
-    @abc.abstractmethod
-    def get_sample_from_time(self, time: float) -> int: ...
-
-    @abc.abstractmethod
     def get_recording_length(self) -> float: ...
 
     @abc.abstractmethod
@@ -61,6 +55,24 @@ class AbstractDataModel(abc.ABC):
         per-channel ``atlas_id`` in their header override this.
         """
         return None
+
+    def get_t0(self) -> float:
+        """Time in seconds of sample 0, i.e. the recording's clock origin.
+
+        Defaults to zero; backends whose clock does not start at zero
+        (e.g. a SpikeInterface recording shifted with ``set_times``) override
+        this. Sampling is assumed linear from this origin: drift within the
+        recording is not modeled.
+        """
+        return 0.0
+
+    def get_time_from_sample(self, sample: int) -> float:
+        """Time in seconds of a sample index, assuming a linear clock."""
+        return self.get_t0() + sample / self.get_sampling_frequency()
+
+    def get_sample_from_time(self, time: float) -> int:
+        """Sample index of a time in seconds, assuming a linear clock."""
+        return int(round((time - self.get_t0()) * self.get_sampling_frequency()))
 
 
 class SpikeGLXDataModel(AbstractDataModel):
@@ -169,16 +181,6 @@ class SpikeGLXDataModel(AbstractDataModel):
     def get_sampling_frequency(self) -> float:
         """Sampling frequency (Hz) of the recording."""
         return self.sr.fs
-
-    @override
-    def get_time_from_sample(self, sample: int) -> float:
-        """Time in seconds of a sample index (zero-origin regular clock)."""
-        return sample / self.sr.fs
-
-    @override
-    def get_sample_from_time(self, time: float) -> int:
-        """Sample index of a time in seconds (zero-origin regular clock)."""
-        return int(round(time * self.sr.fs))
 
     @override
     def get_recording_length(self) -> float:
@@ -429,14 +431,9 @@ class SpikeInterfaceDataModel(AbstractDataModel):
         return self.first_recording.get_sampling_frequency()
 
     @override
-    def get_time_from_sample(self, sample: int) -> float:
-        """Time in seconds of a sample index"""
-        return self.first_recording.sample_index_to_time(sample, segment_index=0)
-
-    @override
-    def get_sample_from_time(self, time: float) -> int:
-        """Sample index of a time in seconds"""
-        return self.first_recording.time_to_sample_index(time, segment_index=0)
+    def get_t0(self) -> float:
+        """Time in seconds of sample 0 on the SpikeInterface recording's clock."""
+        return self.first_recording.sample_index_to_time(0, segment_index=0)
 
     @override
     def get_recording_length(self) -> float:

--- a/src/viewephys/data_model.py
+++ b/src/viewephys/data_model.py
@@ -28,6 +28,12 @@ class AbstractDataModel(abc.ABC):
     def get_sampling_frequency(self) -> float: ...
 
     @abc.abstractmethod
+    def get_time_from_sample(self, sample: int) -> float: ...
+
+    @abc.abstractmethod
+    def get_sample_from_time(self, time: float) -> int: ...
+
+    @abc.abstractmethod
     def get_recording_length(self) -> float: ...
 
     @abc.abstractmethod
@@ -163,6 +169,16 @@ class SpikeGLXDataModel(AbstractDataModel):
     def get_sampling_frequency(self) -> float:
         """Sampling frequency (Hz) of the recording."""
         return self.sr.fs
+
+    @override
+    def get_time_from_sample(self, sample: int) -> float:
+        """Time in seconds of a sample index (zero-origin regular clock)."""
+        return sample / self.sr.fs
+
+    @override
+    def get_sample_from_time(self, time: float) -> int:
+        """Sample index of a time in seconds (zero-origin regular clock)."""
+        return int(round(time * self.sr.fs))
 
     @override
     def get_recording_length(self) -> float:
@@ -411,6 +427,16 @@ class SpikeInterfaceDataModel(AbstractDataModel):
     @override
     def get_sampling_frequency(self) -> float:
         return self.first_recording.get_sampling_frequency()
+
+    @override
+    def get_time_from_sample(self, sample: int) -> float:
+        """Time in seconds of a sample index"""
+        return self.first_recording.sample_index_to_time(sample, segment_index=0)
+
+    @override
+    def get_sample_from_time(self, time: float) -> int:
+        """Sample index of a time in seconds"""
+        return self.first_recording.time_to_sample_index(time, segment_index=0)
 
     @override
     def get_recording_length(self) -> float:

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -317,10 +317,9 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         if t is None:
             return
 
-        sampling_frequency = self.data.get_sampling_frequency()
         num_samples = self.data.get_num_samples()
 
-        requested_sample = int(round(t * sampling_frequency))
+        requested_sample = self.data.get_sample_from_time(t)
         requested_sample = max(0, min(requested_sample, int(num_samples) - 1))
         max_first = max(0, int(num_samples) - self.window_length_n)
         first_sample = requested_sample - self.window_length_n // 2

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -285,17 +285,16 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         if not hasattr(self, "data"):
             return
         num_samples = self.data.get_num_samples()
-        sampling_frequency = self.data.get_sampling_frequency()
         n_chunks = int(np.floor(num_samples / self.window_length_n))
         self.horizontalSlider.setMaximum(n_chunks)
-        tmax = n_chunks * self.window_length_n / sampling_frequency
+        tmax = self.data.get_time_from_sample(num_samples - 1)
         self.label_smax.setText(f"{tmax:0.2f}s")
 
     def _update_time_label(self) -> None:
         if not hasattr(self, "data"):
             self.lineEdit_jumpTime.setText("0.000000")
             return
-        tcur = self._first_sample / self.data.get_sampling_frequency()
+        tcur = self.data.get_time_from_sample(self._first_sample)
         self.lineEdit_jumpTime.setText(f"{tcur:0.6f}")
 
     def _get_float_from_lineedit(self, lineedit: QtWidgets.QLineEdit):
@@ -327,7 +326,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         first_sample = requested_sample - self.window_length_n // 2
 
         first_sample = max(0, min(first_sample, max_first))
-        center_time = requested_sample / sampling_frequency
+        center_time = self.data.get_time_from_sample(requested_sample)
         self._first_sample = first_sample
         slider_value = int(round(first_sample / self.window_length_n))
         slider_value = max(0, min(slider_value, self.horizontalSlider.maximum()))
@@ -365,7 +364,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
 
         first = int(self._first_sample)
         last = first + int(self.window_length_n)
-        t0 = first / self.data.get_sampling_frequency()
+        t0 = self.data.get_time_from_sample(first)
 
         # Old data flow preserved: fetch raw once, branch per preprocessing step.
         # A fully general interface would re-fetch inside each get_data() call

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -93,8 +93,6 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.lineEdit_windowSize.returnPressed.connect(
             self.on_lineEdit_windowSizeChanged
         )
-        self.label_smin.setText("0")
-
         self._update_time_label()
         self.show()
 
@@ -165,20 +163,6 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.data = SpikeGLXDataModel(sr)
 
     def _setup_slider(self):
-        num_samples = self.data.get_num_samples()
-        sampling_frequency = self.data.get_sampling_frequency()
-
-        # enable and set slider, based on the number of samples in the entire file
-        self.horizontalSlider.setMaximum(
-            int(np.floor(num_samples / self.window_length_n))
-        )
-        tmax = (
-            np.floor(num_samples / self.window_length_n)
-            * self.window_length_n
-            / sampling_frequency
-        )
-        self.label_smax.setText(f"{tmax:0.2f}s")
-
         tlabel = self._create_top_label()
         self.update_slider_limits()
 
@@ -289,6 +273,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.horizontalSlider.setMaximum(n_chunks)
         tmax = self.data.get_time_from_sample(num_samples - 1)
         self.label_smax.setText(f"{tmax:0.2f}s")
+        tmin = self.data.get_time_from_sample(0)
+        self.label_smin.setText(f"{tmin:0.2f}s")
 
     def _update_time_label(self) -> None:
         if not hasattr(self, "data"):

--- a/src/viewephys/tests/test_spikeinterface.py
+++ b/src/viewephys/tests/test_spikeinterface.py
@@ -34,6 +34,15 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
     window.update_slider_limits()
     fs = window.data.get_sampling_frequency()
 
+    # The slider min/max labels report the absolute start/end time on the SI
+    # clock, so they must reflect the +T_START offset (not the zero-origin
+    # sample/fs values).
+    expected_tmin = window.data.get_time_from_sample(0)
+    expected_tmax = window.data.get_time_from_sample(window.data.get_num_samples() - 1)
+    assert expected_tmin == pytest.approx(T_START)
+    assert window.label_smin.text() == f"{expected_tmin:0.2f}s"
+    assert window.label_smax.text() == f"{expected_tmax:0.2f}s"
+
     # Check that dynamic checkboxes mirror the recording dict order and labels.
     assert list(window.cbs) == list(recordings)
     assert [checkbox.text() for checkbox in window.cbs.values()] == list(recordings)

--- a/src/viewephys/tests/test_spikeinterface.py
+++ b/src/viewephys/tests/test_spikeinterface.py
@@ -80,3 +80,49 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
         assert viewer.model.t0 == pytest.approx(expected_t0)
 
     window.close()
+
+
+def test_spikeinterface_jump_to_time_uses_si_clock(qtbot):
+    """Jumping to a typed time must convert through the SI clock.
+
+    With a non-zero start time, ``get_sample_from_time`` and the old zero-origin
+    ``t * fs`` conversion land on very different samples, so this guards against
+    the jump handler regressing to plain ``t * fs``.
+    """
+    fs = 30_000.0
+    raw = si_core.generate_recording(
+        num_channels=4,
+        sampling_frequency=fs,
+        durations=[0.2],
+        set_probe=False,
+        seed=0,
+    )
+    raw.set_times(raw.get_times() + T_START)
+
+    window = EphysBinViewer({"raw": raw})
+    window.window_length_n = 64
+    window.update_slider_limits()
+    # Do not spawn viewer windows; we only assert the navigation maths.
+    for checkbox in window.cbs.values():
+        checkbox.setChecked(False)
+
+    ns = raw.get_num_samples()
+    max_first = max(0, ns - window.window_length_n)
+
+    # Jump 0.05 s into the recording on the SI clock (i.e. T_START + 0.05 s).
+    target_time = T_START + 0.05
+    window.lineEdit_jumpTime.setText(f"{target_time:.6f}")
+    window.on_jumpToTimeRequested()
+
+    # Expected window start from the correct SI-clock conversion...
+    requested = min(max(0, window.data.get_sample_from_time(target_time)), ns - 1)
+    expected_first = min(max(0, requested - window.window_length_n // 2), max_first)
+    # ...versus the old zero-origin bug (t * fs), which clamps far to the right.
+    buggy = min(max(0, int(round(target_time * fs))), ns - 1)
+    buggy_first = min(max(0, buggy - window.window_length_n // 2), max_first)
+
+    assert window._first_sample == expected_first
+    # If this fails the two conversions coincide and the test is toothless.
+    assert expected_first != buggy_first
+
+    window.close()

--- a/src/viewephys/tests/test_spikeinterface.py
+++ b/src/viewephys/tests/test_spikeinterface.py
@@ -117,12 +117,7 @@ def test_spikeinterface_jump_to_time_uses_si_clock(qtbot):
     # Expected window start from the correct SI-clock conversion...
     requested = min(max(0, window.data.get_sample_from_time(target_time)), ns - 1)
     expected_first = min(max(0, requested - window.window_length_n // 2), max_first)
-    # ...versus the old zero-origin bug (t * fs), which clamps far to the right.
-    buggy = min(max(0, int(round(target_time * fs))), ns - 1)
-    buggy_first = min(max(0, buggy - window.window_length_n // 2), max_first)
 
     assert window._first_sample == expected_first
-    # If this fails the two conversions coincide and the test is toothless.
-    assert expected_first != buggy_first
 
     window.close()

--- a/src/viewephys/tests/test_spikeinterface.py
+++ b/src/viewephys/tests/test_spikeinterface.py
@@ -1,8 +1,13 @@
 import numpy as np
+import pytest
 import spikeinterface.core as si_core
 import spikeinterface.preprocessing as si_prepro
 
 from viewephys.gui import A_SCALAR, EphysBinViewer
+
+# The SpikeInterface recordings below are shifted onto a non-zero clock so the
+# tests exercise the sample<->time mapping (t0/labels), not just frame slicing.
+T_START = 40.0
 
 
 def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
@@ -15,6 +20,9 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
         seed=0,
     )
 
+    # Shift onto a non-zero clock (mimics an SI recording that does not start at 0).
+    raw.set_times(raw.get_times() + T_START)
+
     # Add preprocessing steps, preserving dict order as the expected UI order.
     bandpass = si_prepro.bandpass_filter(raw, freq_min=125.0, freq_max=3000)
     cmr = si_prepro.common_reference(bandpass, operator="median")
@@ -24,6 +32,7 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
     window = EphysBinViewer(recordings)
     window.window_length_n = 64
     window.update_slider_limits()
+    fs = window.data.get_sampling_frequency()
 
     # Check that dynamic checkboxes mirror the recording dict order and labels.
     assert list(window.cbs) == list(recordings)
@@ -46,7 +55,8 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
     assert list(window.viewers) == list(recordings)
     assert all(viewer is not None for viewer in window.viewers.values())
 
-    # Verify each spawned viewer displays the matching SpikeInterface trace slice.
+    # The window content is selected by sample index, so the frame slice is
+    # unaffected by the non-zero clock: each viewer shows the matching traces.
     for step, viewer in window.viewers.items():
         expected = (
             recordings[step].get_traces(
@@ -60,5 +70,13 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
         np.testing.assert_allclose(
             viewer.imageItem_seismic.image, expected, rtol=0, atol=1e-8
         )
+
+    # The non-zero SI clock must be honored for display: the sample<->time helper
+    # and every spawned viewer's time origin reflect the +T_START offset.
+    expected_t0 = first / fs + T_START
+    assert window.data.get_time_from_sample(first) == pytest.approx(expected_t0)
+    assert window.lineEdit_jumpTime.text() == f"{expected_t0:0.6f}"
+    for viewer in window.viewers.values():
+        assert viewer.model.t0 == pytest.approx(expected_t0)
 
     window.close()


### PR DESCRIPTION
SpikeInterface recordings can have time arrays that do not start at zero. This PR exposes a `get_time_from_sample` and `get_sample_from_time` that call the spikeinterface corresponding functions to ensure the times match. For the non-spikeinterface path it returns the old implementation.

One thing this does not cover is non-uniform sampling intervals, which I guess can be an issue with drifting clock. This would be largely cosmetic e.g. overwriting the xtick labels on the plot based on the SpikeInterface time vector (if found). However, I'm not sure how important it is, I think the current implementation will cover nearly all cases? 