### PR TITLE
Rework slider

### DIFF
--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -44,7 +44,7 @@ SNS_PALETTE = [
     (0.09019607843137255, 0.7450980392156863, 0.8117647058823529),
 ]
 
-SLIDER_MAXVAL = 2**16 - 1  # TODO: CHECK
+SLIDER_MAXVAL = 2**31 - 1
 
 
 class EphysBinViewer(QtWidgets.QMainWindow):
@@ -241,14 +241,24 @@ class EphysBinViewer(QtWidgets.QMainWindow):
 
     def on_horizontalSliderValueChanged(self) -> None:
         value = self.horizontalSlider.value()
-        slider_max = self.horizontalSlider.maximum()
-        self._first_sample = min(
-            self.data.get_num_samples() - self.window_length_n,
-            int(value / SLIDER_MAXVAL * self.data.get_num_samples()),
-        )  # int(self.horizontalSlider.value()) * self.window_length_n
-        print("value", value)
-        print("slider_max", slider_max)
-        print("first sample", self._first_sample)
+        num_samples = self.data.get_num_samples()
+
+        max_sample = num_samples - self.window_length_n
+        current_sample = int(value / SLIDER_MAXVAL * self.data.get_num_samples())
+
+        if max_sample < current_sample:
+            # Don't allow the slider to go to the end as we must account for the
+            # window size (slider value sets the first sample)
+            self._first_sample = max_sample
+            capped_value = round(
+                SLIDER_MAXVAL * ((num_samples - self.window_length_n) / num_samples)
+            )
+            self.horizontalSlider.blockSignals(True)
+            self.horizontalSlider.setValue(capped_value)
+            self.horizontalSlider.blockSignals(False)
+        else:
+            self._first_sample = current_sample
+
         self._update_time_label()
 
     def on_lineEdit_windowSizeChanged(self) -> None:

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -44,6 +44,8 @@ SNS_PALETTE = [
     (0.09019607843137255, 0.7450980392156863, 0.8117647058823529),
 ]
 
+SLIDER_MAXVAL = 2**16 - 1  # TODO: CHECK
+
 
 class EphysBinViewer(QtWidgets.QMainWindow):
     def __init__(
@@ -163,6 +165,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.data = SpikeGLXDataModel(sr)
 
     def _setup_slider(self):
+
         tlabel = self._create_top_label()
         self.update_slider_limits()
 
@@ -238,7 +241,15 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         return tlabel
 
     def on_horizontalSliderValueChanged(self) -> None:
-        self._first_sample = int(self.horizontalSlider.value()) * self.window_length_n
+        value = self.horizontalSlider.value()
+        slider_max = self.horizontalSlider.maximum()
+        self._first_sample = min(
+            self.data.get_num_samples() - self.window_length_n,
+            int(value / SLIDER_MAXVAL * self.data.get_num_samples()),
+        )  # int(self.horizontalSlider.value()) * self.window_length_n
+        print("value", value)
+        print("slider_max", slider_max)
+        print("first sample", self._first_sample)
         self._update_time_label()
 
     def on_lineEdit_windowSizeChanged(self) -> None:
@@ -261,7 +272,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         if not hasattr(self, "data"):
             return
         self.lineEdit_windowSize.setText(
-            f"{self.window_length_n / self.data.get_sampling_frequency():0.2f}"
+            f"{self.window_length_n / self.data.get_sampling_frequency():0.3f}"
         )
 
     def update_slider_limits(self) -> None:
@@ -269,8 +280,8 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         if not hasattr(self, "data"):
             return
         num_samples = self.data.get_num_samples()
-        n_chunks = int(np.floor(num_samples / self.window_length_n))
-        self.horizontalSlider.setMaximum(n_chunks)
+        # n_chunks = int(np.floor(num_samples / self.window_length_n))
+        self.horizontalSlider.setMaximum(SLIDER_MAXVAL)
         tmax = self.data.get_time_from_sample(num_samples - 1)
         self.label_smax.setText(f"{tmax:0.2f}s")
         tmin = self.data.get_time_from_sample(0)
@@ -281,7 +292,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             self.lineEdit_jumpTime.setText("0.000000")
             return
         tcur = self.data.get_time_from_sample(self._first_sample)
-        self.lineEdit_jumpTime.setText(f"{tcur:0.6f}")
+        self.lineEdit_jumpTime.setText(f"{tcur:0.3f}")
 
     def _get_float_from_lineedit(self, lineedit: QtWidgets.QLineEdit):
         text = lineedit.text().strip()

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -244,7 +244,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         num_samples = self.data.get_num_samples()
 
         max_sample = num_samples - self.window_length_n
-        current_sample = int(value / SLIDER_MAXVAL * self.data.get_num_samples())
+        current_sample = round(value / SLIDER_MAXVAL * num_samples)
 
         if max_sample < current_sample:
             # Don't allow the slider to go to the end as we must account for the
@@ -281,7 +281,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         if not hasattr(self, "data"):
             return
         self.lineEdit_windowSize.setText(
-            f"{self.window_length_n / self.data.get_sampling_frequency():0.3f}"
+            f"{self.window_length_n / self.data.get_sampling_frequency():0.6f}"
         )
 
     def update_slider_limits(self) -> None:
@@ -301,7 +301,7 @@ class EphysBinViewer(QtWidgets.QMainWindow):
             self.lineEdit_jumpTime.setText("0.000000")
             return
         tcur = self.data.get_time_from_sample(self._first_sample)
-        self.lineEdit_jumpTime.setText(f"{tcur:0.3f}")
+        self.lineEdit_jumpTime.setText(f"{tcur:0.6f}")
 
     def _get_float_from_lineedit(self, lineedit: QtWidgets.QLineEdit):
         text = lineedit.text().strip()

--- a/src/viewephys/gui.py
+++ b/src/viewephys/gui.py
@@ -165,7 +165,6 @@ class EphysBinViewer(QtWidgets.QMainWindow):
         self.data = SpikeGLXDataModel(sr)
 
     def _setup_slider(self):
-
         tlabel = self._create_top_label()
         self.update_slider_limits()
 

--- a/src/viewephys/tests/test_spikeinterface.py
+++ b/src/viewephys/tests/test_spikeinterface.py
@@ -3,7 +3,7 @@ import pytest
 import spikeinterface.core as si_core
 import spikeinterface.preprocessing as si_prepro
 
-from viewephys.gui import A_SCALAR, EphysBinViewer
+from viewephys.gui import A_SCALAR, SLIDER_MAXVAL, EphysBinViewer
 
 # The SpikeInterface recordings below are shifted onto a non-zero clock so the
 # tests exercise the sample<->time mapping (t0/labels), not just frame slicing.
@@ -56,10 +56,11 @@ def test_spikeinterface_checkboxes_show_selected_recordings(qtbot):
     for checkbox in window.cbs.values():
         checkbox.setChecked(True)
 
-    window.horizontalSlider.setValue(1)
+    slider_val = 45000
+    window.horizontalSlider.setValue(slider_val)
     window.on_horizontalSliderReleased()
 
-    first = window.window_length_n
+    first = round(slider_val / SLIDER_MAXVAL * window.data.get_num_samples())
     last = first + window.window_length_n
     assert list(window.viewers) == list(recordings)
     assert all(viewer is not None for viewer in window.viewers.values())

--- a/src/viewephys/tests/test_viewer_gui.py
+++ b/src/viewephys/tests/test_viewer_gui.py
@@ -8,6 +8,7 @@ from qtpy import QtCore, QtWidgets
 from viewephys.data_model import LFPackDataModel, SpikeGLXDataModel
 from viewephys.gui import (
     A_SCALAR,
+    SLIDER_MAXVAL,
     EphysBinViewer,
     LFPackBinViewer,
     create_app,
@@ -303,9 +304,11 @@ def test_slider_drag_resets_first_sample_to_chunk(jump_window, qtbot):
     assert window._first_sample == 14_999_500  # not chunk-aligned
 
     window.horizontalSlider.setValue(1501)
-    assert window._first_sample == 1501 * window.window_length_n
+    assert window._first_sample == round(
+        (1501 / SLIDER_MAXVAL) * window.data.get_num_samples()
+    )
     assert window.lineEdit_jumpTime.text() == (
-        f"{1501 * window.window_length_n / window.data.get_sampling_frequency():0.6f}"
+        f"{window.data.get_time_from_sample(window._first_sample):0.6f}"
     )
 
 
@@ -442,7 +445,7 @@ def test_window_size_change_displays_different_data(qtbot):
     # Move the slider to start one second (fs samples) into the recording and
     # check the raw viewer now shows that later chunk.
     fs = window.data.get_sampling_frequency()
-    slider_value = int(fs // n1)
+    slider_value = round(fs / window.data.get_num_samples() * SLIDER_MAXVAL)
     window.horizontalSlider.setValue(slider_value)
     window.on_horizontalSliderReleased()
     first = int(fs)


### PR DESCRIPTION
(branched from #54, requires that to be merged before this)

Currently, the slider value is based on the window chunk size. For larger window sizes, this can create strange behaviour e.g. a 5s window on a 25s recording means there are only 5 valid values on the slider.

This PR reconfigures how the slider works by breaking it up into `2**31-1` values, as Qt has an `int32` cutoff on the C++ side. Given these values, the corresponding sample number is mapped through simple scaling `round(slider value / slider max-value * num_samples)`

There is now a new limit on how far the slider can be moved to the right - it will stop when it is 1-window size away from the end.

Currently, the slider position sets the first value of the window, but the lineedit sets the centre-value. Is it worth aligning these so the input time to the lineedit sets the first value of the window, rather than the centre? I don't feel strongly on this, though it creates one confusing behaviour that when the slider moves the lineedit indicates the first sample of the window. but if 'enter' is pressed on the lineedit, it then jumps such that the value is the centre value of the window.
